### PR TITLE
[47] Update file upload management

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ If you need to upload PDF files directly (instead of passing URLs), use:
 
 This endpoint uploads PDFs to object storage and enqueues `parsePdf` jobs using a stable public URL. PDFs are stored using **content-hash keys** to avoid duplicates:
 
-- Key format: `uploads/{env}/{sha256}.pdf` where `{env}` is `UPLOADS_ENV` (or derived from `NODE_ENV`)
 - Key format: `uploads/{env}/{sha256}.pdf` where `{env}` is derived from `NODE_ENV`:
   - `production` → `prod`
   - `staging` → `stage`
@@ -74,12 +73,12 @@ It requires `S3_BUCKET` and either:
 
 When adding jobs via `POST /api/queues/parsePdf`, you can set `cachePdf=true` to:
 
-- Fetch each provided URL server-side
+- Fetch each provided URL server-side (overall timeout, capped redirects, `%PDF` header check, and basic blocking of private/reserved destinations—see `src/lib/outbound-pdf-url.ts`)
 - Store the PDF to object storage at `uploads/{env}/{sha256}.pdf`
 - Enqueue the job using the stored URL (so workers read from storage)
 - Preserve the original URL in job data as `sourceUrl` (for UI/history)
 
-The response will include a `cached[]` array with per-URL cache details when caching is enabled.
+The response includes `cached[]` when caching ran. If some URLs fail, you may get `errors[]` alongside successful `jobs` (HTTP 400 if every URL fails). Details: `docs/pdf-caching.md`.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,29 @@ If you need to upload PDF files directly (instead of passing URLs), use:
 
 - `POST /api/queues/parsePdf/upload` (`multipart/form-data`)
 
-This endpoint uploads PDFs to object storage and enqueues `parsePdf` jobs using a stable public URL. It requires `S3_BUCKET` and either:
+This endpoint uploads PDFs to object storage and enqueues `parsePdf` jobs using a stable public URL. PDFs are stored using **content-hash keys** to avoid duplicates:
+
+- Key format: `uploads/{env}/{sha256}.pdf` where `{env}` is `UPLOADS_ENV` (or derived from `NODE_ENV`)
+- Key format: `uploads/{env}/{sha256}.pdf` where `{env}` is derived from `NODE_ENV`:
+  - `production` → `prod`
+  - `staging` → `stage`
+  - otherwise → `dev`
+- Uploading the exact same PDF bytes twice reuses the same object key and returns the existing URL.
+
+It requires `S3_BUCKET` and either:
 - `S3_PUBLIC_BASE_URL`, or
 - `S3_ENDPOINT` (publicly routable; URL constructed as `${S3_ENDPOINT}/${S3_BUCKET}/${key}`).
+
+### PDF Caching for URL-based jobs (optional)
+
+When adding jobs via `POST /api/queues/parsePdf`, you can set `cachePdf=true` to:
+
+- Fetch each provided URL server-side
+- Store the PDF to object storage at `uploads/{env}/{sha256}.pdf`
+- Enqueue the job using the stored URL (so workers read from storage)
+- Preserve the original URL in job data as `sourceUrl` (for UI/history)
+
+The response will include a `cached[]` array with per-URL cache details when caching is enabled.
 
 ### Installation
 

--- a/docs/pdf-caching.md
+++ b/docs/pdf-caching.md
@@ -2,6 +2,15 @@
 
 This API supports **full caching** of PDFs into object storage so the pipeline can operate on stable URLs, even when source links change or become unavailable.
 
+## Authentication
+
+Queue **write** operations (`POST` / `PUT` / `PATCH` / `DELETE` under `/api/queues`, `/api/processes`, `/api/pipeline`) require a valid **JWT** in the `Authorization: Bearer …` header whenever `NODE_ENV` is not `development` (see `src/app.ts`). That includes:
+
+- `POST /api/queues/parsePdf/upload`
+- `POST /api/queues/parsePdf` (including `cachePdf: true`)
+
+`cachePdf` performs **server-side HTTP fetches** from user-supplied URLs. JWT limits anonymous abuse, but you should still treat callers as **trusted** for outbound network policy, or extend URL validation (this codebase blocks private/reserved IPs, credentials in URLs, and non-http(s) schemes—see `src/lib/outbound-pdf-url.ts`).
+
 ## Storage layout
 
 - **Key format**: `uploads/{env}/{sha256}.pdf`
@@ -14,7 +23,7 @@ This API supports **full caching** of PDFs into object storage so the pipeline c
 ## Dedupe behavior
 
 - If two PDFs are **byte-identical**, they will produce the same SHA-256 and therefore the same object key.
-  - The API will **reuse** the existing object and return the existing URL.
+  - The API will **reuse** the existing object and return its URL.
 - If two PDFs are “similar” but not identical (e.g. different year, changed numbers, regenerated PDF metadata), they will produce different hashes and will be stored separately.
 
 In practice, SHA-256 collisions are considered negligible for this use case.
@@ -34,15 +43,15 @@ In practice, SHA-256 collisions are considered negligible for this use case.
 
 `POST /api/queues/parsePdf` with JSON body including `cachePdf=true`
 
-- Fetches each URL server-side, caches the PDF to S3, and enqueues the job using the cached S3 URL.
+- Fetches each URL server-side (with redirect cap, overall timeout, PDF magic-byte check, and basic SSRF guards), caches the PDF to S3, and enqueues the job using the cached S3 URL.
 - The original URL is preserved in job data as `sourceUrl`.
+- **Partial success**: if some URLs fail and others succeed, the response is **200** with `jobs`, `cached`, and an `errors` array `{ url, error }[]`. If **every** URL fails, the API returns **400** with `error` and `errors`.
 
 ## Redis mapping (“URL table”)
 
 When caching from URLs, the API stores a mapping in Redis so repeated submissions can skip refetching:
 
 - **URL → cache entry**: `pdf:urlmap:{env}:{sha1(sourceUrl)}`
-- **SHA → cache entry**: `pdf:shamap:{env}:{sha256}`
 
 The stored value is a JSON blob containing:
 `{ env, sourceUrl, sha256, bucket, key, publicUrl, reusedExisting, uploaded, fetchedAt, contentLength? }`
@@ -64,4 +73,3 @@ These Redis keys are stored with a **14-day TTL**. After expiry, the next reques
 
 - Consider S3 lifecycle rules for `uploads/dev/*` and/or `uploads/stage/*` to avoid long-term accumulation during testing.
 - Cached PDFs are full copies stored in your bucket.
-

--- a/docs/pdf-caching.md
+++ b/docs/pdf-caching.md
@@ -1,0 +1,67 @@
+# PDF caching & dedupe (S3)
+
+This API supports **full caching** of PDFs into object storage so the pipeline can operate on stable URLs, even when source links change or become unavailable.
+
+## Storage layout
+
+- **Key format**: `uploads/{env}/{sha256}.pdf`
+  - `{env}` is derived from `NODE_ENV`:
+    - `production` → `prod`
+    - `staging` → `stage`
+    - otherwise → `dev`
+  - `{sha256}` is the SHA-256 hex digest of the PDF bytes.
+
+## Dedupe behavior
+
+- If two PDFs are **byte-identical**, they will produce the same SHA-256 and therefore the same object key.
+  - The API will **reuse** the existing object and return the existing URL.
+- If two PDFs are “similar” but not identical (e.g. different year, changed numbers, regenerated PDF metadata), they will produce different hashes and will be stored separately.
+
+In practice, SHA-256 collisions are considered negligible for this use case.
+
+## Endpoints
+
+### Upload PDF files (multipart)
+
+`POST /api/queues/parsePdf/upload`
+
+- Uploads one or more PDFs to S3 and enqueues `parsePdf` jobs using the stored URL.
+- Response includes per-file metadata:
+  - `reusedExisting`: true if the object already existed
+  - `uploaded`: true if a new object was stored in this request
+
+### Enqueue from URLs with full cache
+
+`POST /api/queues/parsePdf` with JSON body including `cachePdf=true`
+
+- Fetches each URL server-side, caches the PDF to S3, and enqueues the job using the cached S3 URL.
+- The original URL is preserved in job data as `sourceUrl`.
+
+## Redis mapping (“URL table”)
+
+When caching from URLs, the API stores a mapping in Redis so repeated submissions can skip refetching:
+
+- **URL → cache entry**: `pdf:urlmap:{env}:{sha1(sourceUrl)}`
+- **SHA → cache entry**: `pdf:shamap:{env}:{sha256}`
+
+The stored value is a JSON blob containing:
+`{ env, sourceUrl, sha256, bucket, key, publicUrl, reusedExisting, uploaded, fetchedAt, contentLength? }`
+
+This behaves like a lightweight “table” without requiring a SQL database in `pipeline-api`.
+
+### Retention / TTL
+
+These Redis keys are stored with a **14-day TTL**. After expiry, the next request will refetch the PDF from the source URL and re-cache it.
+
+## Environment variables
+
+- **Required for caching**:
+  - `S3_BUCKET`
+  - `S3_PUBLIC_BASE_URL` or `S3_ENDPOINT`
+  - `NODE_ENV` should be set correctly (`staging` in stage; `production` in prod).
+
+## Operational notes
+
+- Consider S3 lifecycle rules for `uploads/dev/*` and/or `uploads/stage/*` to avoid long-term accumulation during testing.
+- Cached PDFs are full copies stored in your bucket.
+

--- a/src/lib/outbound-pdf-url.ts
+++ b/src/lib/outbound-pdf-url.ts
@@ -1,0 +1,119 @@
+import dns from "node:dns/promises";
+import net from "node:net";
+
+/** Total time budget for the entire redirect chain + body download. */
+export const PDF_FETCH_TIMEOUT_MS = 120_000;
+export const PDF_FETCH_MAX_REDIRECTS = 5;
+
+const BLOCKED_HOSTNAMES = new Set(
+  [
+    "localhost",
+    "metadata.google.internal",
+    "metadata",
+    "metadata.gke.internal",
+    "kubernetes.default",
+    "kubernetes.default.svc",
+  ].map((h) => h.toLowerCase()),
+);
+
+function isPrivateOrReservedIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
+    return true;
+  }
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 0) return true;
+  if (a === 169 && parts[1] === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 192 && b === 0 && parts[2] === 0) return true;
+  return false;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const n = ip.toLowerCase();
+  if (n === "::1") return true;
+  if (n.startsWith("fe80:")) return true;
+  if (n.startsWith("fc") || n.startsWith("fd")) return true;
+  return false;
+}
+
+/**
+ * Reject URLs that would let server-side fetch reach private networks or obvious SSRF targets.
+ * Call again after each redirect target is resolved.
+ */
+export async function assertUrlSafeForServerFetch(urlString: string): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Only http(s) URLs are allowed");
+  }
+
+  if (url.username || url.password) {
+    throw new Error("URL must not contain credentials");
+  }
+
+  const hostname = url.hostname;
+  if (!hostname) {
+    throw new Error("Missing hostname");
+  }
+
+  if (BLOCKED_HOSTNAMES.has(hostname.toLowerCase())) {
+    throw new Error("Host is not allowed for server-side fetch");
+  }
+
+  if (net.isIPv4(hostname)) {
+    if (isPrivateOrReservedIpv4(hostname)) {
+      throw new Error("Private or reserved IPv4 addresses are not allowed");
+    }
+    return;
+  }
+
+  if (net.isIPv6(hostname)) {
+    if (isBlockedIpv6(hostname)) {
+      throw new Error("Private or reserved IPv6 addresses are not allowed");
+    }
+    return;
+  }
+
+  let records: import("node:dns").LookupAddress[];
+  try {
+    records = (await dns.lookup(hostname, { all: true })) as import("node:dns").LookupAddress[];
+  } catch (e: any) {
+    throw new Error(`DNS lookup failed: ${e?.message ?? "unknown error"}`);
+  }
+
+  if (!records.length) {
+    throw new Error("DNS lookup returned no addresses");
+  }
+
+  for (const { address, family } of records) {
+    if (family === 4) {
+      if (isPrivateOrReservedIpv4(address)) {
+        throw new Error("Resolved address is in a private or reserved IPv4 range");
+      }
+    } else if (family === 6) {
+      if (isBlockedIpv6(address)) {
+        throw new Error("Resolved address is in a private or reserved IPv6 range");
+      }
+    }
+  }
+}
+
+export function assertBufferLooksLikePdf(buffer: Buffer): void {
+  if (buffer.length < 4) {
+    throw new Error("Response is too small to be a PDF");
+  }
+  const head = buffer.subarray(0, 5).toString("latin1");
+  if (!head.startsWith("%PDF")) {
+    throw new Error("Response is not a PDF document (missing %PDF header)");
+  }
+}

--- a/src/lib/redis-client.ts
+++ b/src/lib/redis-client.ts
@@ -1,0 +1,18 @@
+import Redis from "ioredis";
+import redisConfig from "../config/redis";
+
+let client: Redis | null = null;
+
+export function getRedisClient(): Redis {
+  if (!client) {
+    client = new Redis({
+      host: redisConfig.host,
+      port: redisConfig.port,
+      ...(redisConfig.password ? { password: redisConfig.password } : {}),
+      // BullMQ uses ioredis too; keep retry behavior reasonable for API.
+      maxRetriesPerRequest: 3,
+    });
+  }
+  return client;
+}
+

--- a/src/routes/readQueues.ts
+++ b/src/routes/readQueues.ts
@@ -34,6 +34,11 @@ const pdfCacheEntrySchema = z.object({
   contentLength: z.number().optional(),
 });
 
+const pdfCacheUrlErrorSchema = z.object({
+  url: z.string(),
+  error: z.string(),
+});
+
 async function uploadAndEnqueueParsePdfJobs(params: {
   queueService: QueueService;
   files: { buffer: Buffer; filename: string }[];
@@ -320,8 +325,13 @@ export async function readQueuesRoute(app: FastifyInstance) {
             z.object({
               jobs: queueAddJobResponseSchema,
               cached: z.array(pdfCacheEntrySchema),
+              errors: z.array(pdfCacheUrlErrorSchema).optional(),
             }),
-          ])
+          ]),
+          400: z.object({
+            error: z.string(),
+            errors: z.array(pdfCacheUrlErrorSchema).optional(),
+          }),
         },
       },
     },
@@ -356,46 +366,69 @@ export async function readQueuesRoute(app: FastifyInstance) {
       const queueService = await QueueService.getQueueService();
       const addedJobs: BaseJob[] = [];
       const cached: PdfCacheEntry[] = [];
-      for(const url of urls) {
+      const cacheErrors: Array<{ url: string; error: string }> = [];
+
+      for (const url of urls) {
         if (resolvedName === QUEUE_NAMES.PARSE_PDF && cachePdf) {
           if (!isS3Configured()) {
             return reply.status(503).send({
               error: 'PDF caching is not configured. Set S3_BUCKET in the environment.',
             });
           }
-          const entry = await cachePdfFromUrl(url);
-          cached.push(entry);
-          // Enqueue with cached URL so workers read from storage, but keep the official link for UI/history.
-          const perUrlThreadId = randomUUID();
-          const addedJob = await queueService.addJob(resolvedName, entry.publicUrl, autoApprove, {
-            forceReindex,
-            threadId: perUrlThreadId,
-            replaceAllEmissions,
-            runOnly,
-            batchId,
-            tags,
-            data: {
-              sourceUrl: url,
-              pdfCache: {
-                sha256: entry.sha256,
-                bucket: entry.bucket,
-                key: entry.key,
-                publicUrl: entry.publicUrl,
-                reusedExisting: entry.reusedExisting,
-                uploaded: entry.uploaded,
-                fetchedAt: entry.fetchedAt,
+          try {
+            const entry = await cachePdfFromUrl(url);
+            const perUrlThreadId = randomUUID();
+            const addedJob = await queueService.addJob(resolvedName, entry.publicUrl, autoApprove, {
+              forceReindex,
+              threadId: perUrlThreadId,
+              replaceAllEmissions,
+              runOnly,
+              batchId,
+              tags,
+              data: {
+                sourceUrl: url,
+                pdfCache: {
+                  sha256: entry.sha256,
+                  bucket: entry.bucket,
+                  key: entry.key,
+                  publicUrl: entry.publicUrl,
+                  reusedExisting: entry.reusedExisting,
+                  uploaded: entry.uploaded,
+                  fetchedAt: entry.fetchedAt,
+                },
               },
-            },
-          });
-          addedJobs.push(addedJob);
+            });
+            addedJobs.push(addedJob);
+            cached.push(entry);
+          } catch (err: any) {
+            const message = err?.message ? String(err.message) : 'Failed to cache or enqueue PDF';
+            request.log.warn({ err, url }, 'parsePdf cachePdf failed for URL');
+            cacheErrors.push({ url, error: message });
+          }
           continue;
         }
-        // Generate a unique threadId for each URL; client-provided threadId is ignored
         const perUrlThreadId = randomUUID();
         const addedJob = await queueService.addJob(resolvedName, url, autoApprove, { forceReindex, threadId: perUrlThreadId, replaceAllEmissions, runOnly, batchId, tags });
         addedJobs.push(addedJob);
       }
-      return reply.send(cached.length > 0 ? { jobs: addedJobs, cached } : addedJobs);
+
+      if (resolvedName === QUEUE_NAMES.PARSE_PDF && cachePdf) {
+        if (cacheErrors.length > 0 && addedJobs.length === 0) {
+          return reply.status(400).send({
+            error: 'Could not cache or enqueue any PDFs from the provided URLs.',
+            errors: cacheErrors,
+          });
+        }
+        if (cached.length > 0 || cacheErrors.length > 0) {
+          return reply.send({
+            jobs: addedJobs,
+            cached,
+            ...(cacheErrors.length > 0 ? { errors: cacheErrors } : {}),
+          });
+        }
+      }
+
+      return reply.send(addedJobs);
     }
   );
 

--- a/src/routes/readQueues.ts
+++ b/src/routes/readQueues.ts
@@ -7,8 +7,32 @@ import { STATUS, QUEUE_NAMES } from "../lib/bullmq";
 import { JobType } from "bullmq";
 import { addQueueJobBodySchema, readQueueJobPathParamsSchema, readQueuePathParamsSchema, readQueueQueryStringSchema, readQueueStatsQueryStringSchema, rerunAndSaveQueueJobBodySchema, rerunJobsByWorkerBodySchema, rerunQueueJobBodySchema } from "../schemas/request";
 import { z } from "zod";
-import { uploadPdfAndGetUrls } from "../services/S3UploadService";
+import { type PdfUploadResult, uploadPdfAndGetUrls } from "../services/S3UploadService";
 import { isS3Configured } from "../config/s3";
+import { cachePdfFromUrl, type PdfCacheEntry } from "../services/PdfCacheService";
+
+const pdfUploadMetaSchema = z.object({
+  filename: z.string(),
+  publicUrl: z.string().url(),
+  bucket: z.string(),
+  key: z.string(),
+  sha256: z.string(),
+  reusedExisting: z.boolean(),
+  uploaded: z.boolean(),
+});
+
+const pdfCacheEntrySchema = z.object({
+  env: z.string(),
+  sourceUrl: z.string().url(),
+  sha256: z.string(),
+  bucket: z.string(),
+  key: z.string(),
+  publicUrl: z.string().url(),
+  reusedExisting: z.boolean(),
+  uploaded: z.boolean(),
+  fetchedAt: z.string(),
+  contentLength: z.number().optional(),
+});
 
 async function uploadAndEnqueueParsePdfJobs(params: {
   queueService: QueueService;
@@ -23,14 +47,18 @@ async function uploadAndEnqueueParsePdfJobs(params: {
   };
   request: FastifyRequest;
   fileTooLargeMessage: string;
-}): Promise<{ ok: true; jobs: BaseJob[] } | { ok: false; status: 413 | 500; error: string }> {
+}): Promise<
+  | { ok: true; jobs: BaseJob[]; uploads: Array<{ filename: string } & PdfUploadResult> }
+  | { ok: false; status: 413 | 500; error: string }
+> {
   const { queueService, files, options, request, fileTooLargeMessage } = params;
 
   const addedJobs: BaseJob[] = [];
+  const uploads: Array<{ filename: string } & PdfUploadResult> = [];
   for (const { buffer, filename } of files) {
-    let publicUrl: string;
+    let upload: PdfUploadResult;
     try {
-      ({ publicUrl } = await uploadPdfAndGetUrls(buffer, filename));
+      upload = await uploadPdfAndGetUrls(buffer, filename);
     } catch (err: any) {
       request.log.warn({ err, filename }, 'S3 upload failed');
       const isTooLarge = err?.message?.includes('too large') ?? false;
@@ -42,23 +70,35 @@ async function uploadAndEnqueueParsePdfJobs(params: {
     }
 
     request.log.info(
-      { filename, url: publicUrl },
+      { filename, url: upload.publicUrl, reusedExisting: upload.reusedExisting, uploaded: upload.uploaded },
       'S3 upload succeeded, adding to BullMQ'
     );
+    uploads.push({ filename, ...upload });
     const perUrlThreadId = randomUUID();
-    const addedJob = await queueService.addJob(QUEUE_NAMES.PARSE_PDF, publicUrl, options.autoApprove ?? false, {
+    const addedJob = await queueService.addJob(QUEUE_NAMES.PARSE_PDF, upload.publicUrl, options.autoApprove ?? false, {
       forceReindex: options.forceReindex,
       threadId: perUrlThreadId,
       replaceAllEmissions: options.replaceAllEmissions,
       runOnly: options.runOnly,
       batchId: options.batchId,
       tags: options.tags,
+      data: {
+        sourceUrl: `uploaded:${filename}`,
+        pdfCache: {
+          sha256: upload.sha256,
+          bucket: upload.bucket,
+          key: upload.key,
+          publicUrl: upload.publicUrl,
+          reusedExisting: upload.reusedExisting,
+          uploaded: upload.uploaded,
+        },
+      },
     });
     request.log.info({ filename, jobId: addedJob.id }, 'BullMQ job added successfully');
     addedJobs.push(addedJob);
   }
 
-  return { ok: true, jobs: addedJobs };
+  return { ok: true, jobs: addedJobs, uploads };
 }
 
 async function parseParsePdfUpload(request: FastifyRequest): Promise<{
@@ -197,7 +237,10 @@ export async function readQueuesRoute(app: FastifyInstance) {
         tags: ['Queues'],
         consumes: ['multipart/form-data'],
         response: {
-          200: queueAddJobResponseSchema,
+          200: z.object({
+            jobs: queueAddJobResponseSchema,
+            uploads: z.array(pdfUploadMetaSchema),
+          }),
           400: z.object({ error: z.string() }),
           413: z.object({ error: z.string() }),
           500: z.object({ error: z.string() }),
@@ -255,7 +298,10 @@ export async function readQueuesRoute(app: FastifyInstance) {
         },
         'ParsePdf upload request completed'
       );
-      return reply.send(uploadResult.jobs);
+      return reply.send({
+        jobs: uploadResult.jobs,
+        uploads: uploadResult.uploads,
+      });
     }
   );
 
@@ -264,12 +310,18 @@ export async function readQueuesRoute(app: FastifyInstance) {
     {
       schema: {
         summary: 'Add job to a queue',
-        description: 'Enqueue one or more URLs into the specified queue. Optional flags include autoApprove, replaceAllEmissions and forceReindex (alias: force-reindex).',
+        description: 'Enqueue one or more URLs into the specified queue. Optional flags include autoApprove, replaceAllEmissions and forceReindex (alias: force-reindex). For parsePdf only: set cachePdf=true to cache PDFs to S3 before enqueueing so workers read from storage.',
         tags: ['Queues'],
         params: readQueuePathParamsSchema,
         body: addQueueJobBodySchema,
         response: {
-          200: queueAddJobResponseSchema
+          200: z.union([
+            queueAddJobResponseSchema,
+            z.object({
+              jobs: queueAddJobResponseSchema,
+              cached: z.array(pdfCacheEntrySchema),
+            }),
+          ])
         },
       },
     },
@@ -285,7 +337,7 @@ export async function readQueuesRoute(app: FastifyInstance) {
       if (!resolvedName) {
         return reply.status(400).send({ error: `Unknown queue '${name}'. Valid queues: ${Object.values(QUEUE_NAMES).join(', ')}` });
       }
-      const { urls, autoApprove, forceReindex, replaceAllEmissions, runOnly, batchId, tags } = request.body as any;
+      const { urls, autoApprove, forceReindex, replaceAllEmissions, runOnly, batchId, tags, cachePdf } = request.body as any;
       // Log enqueue request (sanitized)
       app.log.info(
         {
@@ -297,18 +349,53 @@ export async function readQueuesRoute(app: FastifyInstance) {
           runOnly: runOnly,
           batchId: batchId ?? undefined,
           tags: tags ?? undefined,
+          cachePdf: !!cachePdf,
         },
         'Enqueue request received'
       );
       const queueService = await QueueService.getQueueService();
       const addedJobs: BaseJob[] = [];
+      const cached: PdfCacheEntry[] = [];
       for(const url of urls) {
+        if (resolvedName === QUEUE_NAMES.PARSE_PDF && cachePdf) {
+          if (!isS3Configured()) {
+            return reply.status(503).send({
+              error: 'PDF caching is not configured. Set S3_BUCKET in the environment.',
+            });
+          }
+          const entry = await cachePdfFromUrl(url);
+          cached.push(entry);
+          // Enqueue with cached URL so workers read from storage, but keep the official link for UI/history.
+          const perUrlThreadId = randomUUID();
+          const addedJob = await queueService.addJob(resolvedName, entry.publicUrl, autoApprove, {
+            forceReindex,
+            threadId: perUrlThreadId,
+            replaceAllEmissions,
+            runOnly,
+            batchId,
+            tags,
+            data: {
+              sourceUrl: url,
+              pdfCache: {
+                sha256: entry.sha256,
+                bucket: entry.bucket,
+                key: entry.key,
+                publicUrl: entry.publicUrl,
+                reusedExisting: entry.reusedExisting,
+                uploaded: entry.uploaded,
+                fetchedAt: entry.fetchedAt,
+              },
+            },
+          });
+          addedJobs.push(addedJob);
+          continue;
+        }
         // Generate a unique threadId for each URL; client-provided threadId is ignored
         const perUrlThreadId = randomUUID();
         const addedJob = await queueService.addJob(resolvedName, url, autoApprove, { forceReindex, threadId: perUrlThreadId, replaceAllEmissions, runOnly, batchId, tags });
         addedJobs.push(addedJob);
       }
-      return reply.send(addedJobs);
+      return reply.send(cached.length > 0 ? { jobs: addedJobs, cached } : addedJobs);
     }
   );
 

--- a/src/schemas/request.ts
+++ b/src/schemas/request.ts
@@ -43,6 +43,7 @@ export const addQueueJobBodySchema = z.object({
     runOnly: z.array(z.string()).optional().describe('Array of worker/queue names to run (limits pipeline execution to specified steps)'),
     batchId: z.string().optional().describe('Optional batch ID to group related reports for filtering'),
     tags: z.array(z.string()).optional().describe('Optional tags to set on the job/report at creation (e.g. for filtering); passed through to Garbo API. Worker may set or extend tags later'),
+    cachePdf: z.boolean().optional().default(false).describe('When true (parsePdf only), fetch each URL and cache the PDF to S3 before enqueueing, so pipeline reads from storage instead of the source URL'),
 });
 
 export const rerunQueueJobBodySchema = z.object({

--- a/src/services/PdfCacheService.ts
+++ b/src/services/PdfCacheService.ts
@@ -1,6 +1,12 @@
 import { createHash } from "crypto";
 import { PDF_MAX_BYTES, uploadPdfAndGetUrls, type PdfUploadResult } from "./S3UploadService";
 import { getRedisClient } from "../lib/redis-client";
+import {
+  assertBufferLooksLikePdf,
+  assertUrlSafeForServerFetch,
+  PDF_FETCH_MAX_REDIRECTS,
+  PDF_FETCH_TIMEOUT_MS,
+} from "../lib/outbound-pdf-url";
 
 export type PdfCacheEntry = {
   env: string;
@@ -27,54 +33,72 @@ function sha1Hex(input: string): string {
 }
 
 async function fetchPdfToBuffer(url: string, maxBytes: number): Promise<{ buffer: Buffer; contentLength?: number }> {
-  const res = await fetch(url, {
-    redirect: "follow",
-    headers: {
-      // Some servers behave better with an explicit accept.
-      Accept: "application/pdf,application/octet-stream;q=0.9,*/*;q=0.8",
-    },
-  });
+  let currentUrl = url;
+  const signal = AbortSignal.timeout(PDF_FETCH_TIMEOUT_MS);
 
-  if (!res.ok) {
-    throw new Error(`Failed to fetch PDF (${res.status})`);
-  }
+  for (let redirect = 0; redirect <= PDF_FETCH_MAX_REDIRECTS; redirect++) {
+    await assertUrlSafeForServerFetch(currentUrl);
 
-  const contentLengthHeader = res.headers.get("content-length");
-  const contentLength = contentLengthHeader ? Number(contentLengthHeader) : undefined;
-  if (typeof contentLength === "number" && Number.isFinite(contentLength) && contentLength > maxBytes) {
-    throw new Error(`PDF too large (max ${maxBytes / 1024 / 1024} MB)`);
-  }
+    const res = await fetch(currentUrl, {
+      redirect: "manual",
+      signal,
+      headers: {
+        Accept: "application/pdf,application/octet-stream;q=0.9,*/*;q=0.8",
+      },
+    });
 
-  if (!res.body) {
-    // Node fetch should always have a body for OK responses, but be defensive.
-    const arr = new Uint8Array(await res.arrayBuffer());
-    if (arr.byteLength > maxBytes) throw new Error(`PDF too large (max ${maxBytes / 1024 / 1024} MB)`);
-    return { buffer: Buffer.from(arr), contentLength: arr.byteLength };
-  }
+    if (res.status >= 300 && res.status < 400) {
+      if (res.body) {
+        await res.body.cancel().catch(() => undefined);
+      }
+      const loc = res.headers.get("location");
+      if (!loc) {
+        throw new Error(`Redirect ${res.status} without Location header`);
+      }
+      currentUrl = new URL(loc, currentUrl).href;
+      continue;
+    }
 
-  const chunks: Buffer[] = [];
-  let total = 0;
+    if (!res.ok) {
+      throw new Error(`Failed to fetch PDF (${res.status})`);
+    }
 
-  // Node 18+ uses a web ReadableStream; it supports async iteration.
-  for await (const chunk of res.body as any) {
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    total += buf.length;
-    if (total > maxBytes) {
+    const contentLengthHeader = res.headers.get("content-length");
+    const contentLength = contentLengthHeader ? Number(contentLengthHeader) : undefined;
+    if (typeof contentLength === "number" && Number.isFinite(contentLength) && contentLength > maxBytes) {
       throw new Error(`PDF too large (max ${maxBytes / 1024 / 1024} MB)`);
     }
-    chunks.push(buf);
+
+    if (!res.body) {
+      const arr = new Uint8Array(await res.arrayBuffer());
+      if (arr.byteLength > maxBytes) throw new Error(`PDF too large (max ${maxBytes / 1024 / 1024} MB)`);
+      const buffer = Buffer.from(arr);
+      assertBufferLooksLikePdf(buffer);
+      return { buffer, contentLength: arr.byteLength };
+    }
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+
+    for await (const chunk of res.body as AsyncIterable<Uint8Array | Buffer>) {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buf.length;
+      if (total > maxBytes) {
+        throw new Error(`PDF too large (max ${maxBytes / 1024 / 1024} MB)`);
+      }
+      chunks.push(buf);
+    }
+
+    const buffer = Buffer.concat(chunks, total);
+    assertBufferLooksLikePdf(buffer);
+    return { buffer, contentLength: contentLength ?? total };
   }
 
-  return { buffer: Buffer.concat(chunks, total), contentLength: contentLength ?? total };
+  throw new Error(`Too many redirects (max ${PDF_FETCH_MAX_REDIRECTS})`);
 }
 
 function buildUrlMapKey(env: string, sourceUrl: string): string {
-  // Keep Redis keys short and safe; store the raw URL in the value.
   return `pdf:urlmap:${env}:${sha1Hex(sourceUrl)}`;
-}
-
-function buildShaMapKey(env: string, sha256: string): string {
-  return `pdf:shamap:${env}:${sha256}`;
 }
 
 export async function cachePdfFromUrl(sourceUrl: string): Promise<PdfCacheEntry> {
@@ -83,14 +107,13 @@ export async function cachePdfFromUrl(sourceUrl: string): Promise<PdfCacheEntry>
   const urlKey = buildUrlMapKey(env, sourceUrl);
   const TTL_SECONDS = 14 * 24 * 60 * 60; // 14 days
 
-  // Fast path: if we already cached this URL, reuse.
   const cachedJson = await redis.get(urlKey);
   if (cachedJson) {
     try {
       const parsed = JSON.parse(cachedJson) as PdfCacheEntry;
       if (parsed?.publicUrl && parsed?.key && parsed?.sha256) return parsed;
     } catch {
-      // ignore and recompute
+      /* ignore and recompute */
     }
   }
 
@@ -110,15 +133,8 @@ export async function cachePdfFromUrl(sourceUrl: string): Promise<PdfCacheEntry>
     ...(typeof contentLength === "number" ? { contentLength } : {}),
   };
 
-  // Store both mappings with a bounded TTL so Redis stays a cache (not long-term storage).
-  const shaKey = buildShaMapKey(env, upload.sha256);
   const payload = JSON.stringify(entry);
-  await redis
-    .multi()
-    .set(urlKey, payload, "EX", TTL_SECONDS)
-    .set(shaKey, payload, "EX", TTL_SECONDS)
-    .exec();
+  await redis.set(urlKey, payload, "EX", TTL_SECONDS);
 
   return entry;
 }
-

--- a/src/services/PdfCacheService.ts
+++ b/src/services/PdfCacheService.ts
@@ -1,0 +1,124 @@
+import { createHash } from "crypto";
+import { PDF_MAX_BYTES, uploadPdfAndGetUrls, type PdfUploadResult } from "./S3UploadService";
+import { getRedisClient } from "../lib/redis-client";
+
+export type PdfCacheEntry = {
+  env: string;
+  sourceUrl: string;
+  sha256: string;
+  bucket: string;
+  key: string;
+  publicUrl: string;
+  reusedExisting: boolean;
+  uploaded: boolean;
+  fetchedAt: string;
+  contentLength?: number;
+};
+
+function getUploadEnv(): string {
+  const nodeEnv = (process.env.NODE_ENV ?? "").trim();
+  if (nodeEnv === "production") return "prod";
+  if (nodeEnv === "staging") return "stage";
+  return "dev";
+}
+
+function sha1Hex(input: string): string {
+  return createHash("sha1").update(input).digest("hex");
+}
+
+async function fetchPdfToBuffer(url: string, maxBytes: number): Promise<{ buffer: Buffer; contentLength?: number }> {
+  const res = await fetch(url, {
+    redirect: "follow",
+    headers: {
+      // Some servers behave better with an explicit accept.
+      Accept: "application/pdf,application/octet-stream;q=0.9,*/*;q=0.8",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch PDF (${res.status})`);
+  }
+
+  const contentLengthHeader = res.headers.get("content-length");
+  const contentLength = contentLengthHeader ? Number(contentLengthHeader) : undefined;
+  if (typeof contentLength === "number" && Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error(`PDF too large (max ${maxBytes / 1024 / 1024} MB)`);
+  }
+
+  if (!res.body) {
+    // Node fetch should always have a body for OK responses, but be defensive.
+    const arr = new Uint8Array(await res.arrayBuffer());
+    if (arr.byteLength > maxBytes) throw new Error(`PDF too large (max ${maxBytes / 1024 / 1024} MB)`);
+    return { buffer: Buffer.from(arr), contentLength: arr.byteLength };
+  }
+
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  // Node 18+ uses a web ReadableStream; it supports async iteration.
+  for await (const chunk of res.body as any) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) {
+      throw new Error(`PDF too large (max ${maxBytes / 1024 / 1024} MB)`);
+    }
+    chunks.push(buf);
+  }
+
+  return { buffer: Buffer.concat(chunks, total), contentLength: contentLength ?? total };
+}
+
+function buildUrlMapKey(env: string, sourceUrl: string): string {
+  // Keep Redis keys short and safe; store the raw URL in the value.
+  return `pdf:urlmap:${env}:${sha1Hex(sourceUrl)}`;
+}
+
+function buildShaMapKey(env: string, sha256: string): string {
+  return `pdf:shamap:${env}:${sha256}`;
+}
+
+export async function cachePdfFromUrl(sourceUrl: string): Promise<PdfCacheEntry> {
+  const env = getUploadEnv();
+  const redis = getRedisClient();
+  const urlKey = buildUrlMapKey(env, sourceUrl);
+  const TTL_SECONDS = 14 * 24 * 60 * 60; // 14 days
+
+  // Fast path: if we already cached this URL, reuse.
+  const cachedJson = await redis.get(urlKey);
+  if (cachedJson) {
+    try {
+      const parsed = JSON.parse(cachedJson) as PdfCacheEntry;
+      if (parsed?.publicUrl && parsed?.key && parsed?.sha256) return parsed;
+    } catch {
+      // ignore and recompute
+    }
+  }
+
+  const { buffer, contentLength } = await fetchPdfToBuffer(sourceUrl, PDF_MAX_BYTES);
+  const upload: PdfUploadResult = await uploadPdfAndGetUrls(buffer, sourceUrl);
+
+  const entry: PdfCacheEntry = {
+    env,
+    sourceUrl,
+    sha256: upload.sha256,
+    bucket: upload.bucket,
+    key: upload.key,
+    publicUrl: upload.publicUrl,
+    reusedExisting: upload.reusedExisting,
+    uploaded: upload.uploaded,
+    fetchedAt: new Date().toISOString(),
+    ...(typeof contentLength === "number" ? { contentLength } : {}),
+  };
+
+  // Store both mappings with a bounded TTL so Redis stays a cache (not long-term storage).
+  const shaKey = buildShaMapKey(env, upload.sha256);
+  const payload = JSON.stringify(entry);
+  await redis
+    .multi()
+    .set(urlKey, payload, "EX", TTL_SECONDS)
+    .set(shaKey, payload, "EX", TTL_SECONDS)
+    .exec();
+
+  return entry;
+}
+

--- a/src/services/QueueService.ts
+++ b/src/services/QueueService.ts
@@ -129,6 +129,8 @@ export class QueueService {
             runOnly?: string[];
             batchId?: string;
             tags?: string[];
+            /** Extra job data to merge in (e.g. sourceUrl, cache metadata). */
+            data?: Record<string, any>;
         }
     ): Promise<BaseJob> {
         const queue = await this.getQueue(queueName);
@@ -143,6 +145,7 @@ export class QueueService {
             ...(options?.runOnly ? { runOnly: options.runOnly } : {}),
             ...(options?.batchId ? { batchId: options.batchId } : {}),
             ...(options?.tags?.length ? { tags: options.tags } : {}),
+            ...(options?.data ? options.data : {}),
         });
         return transformJobtoBaseJob(job);
     }

--- a/src/services/QueueService.ts
+++ b/src/services/QueueService.ts
@@ -136,16 +136,16 @@ export class QueueService {
         const queue = await this.getQueue(queueName);
         const id = crypto.randomUUID();
         const job = await queue.add('download ' + url.slice(-20), {
-            url: url.trim(),
-            autoApprove,
-            id,
+            ...(options?.data ? options.data : {}),
             ...(options?.threadId ? { threadId: options.threadId } : {}),
             ...(options?.forceReindex !== undefined ? { forceReindex: options.forceReindex } : {}),
             ...(options?.replaceAllEmissions !== undefined ? { replaceAllEmissions: options.replaceAllEmissions } : {}),
             ...(options?.runOnly ? { runOnly: options.runOnly } : {}),
             ...(options?.batchId ? { batchId: options.batchId } : {}),
             ...(options?.tags?.length ? { tags: options.tags } : {}),
-            ...(options?.data ? options.data : {}),
+            autoApprove,
+            id,
+            url: url.trim(),
         });
         return transformJobtoBaseJob(job);
     }

--- a/src/services/S3UploadService.ts
+++ b/src/services/S3UploadService.ts
@@ -1,7 +1,7 @@
-import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { HeadObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { S3Client } from '@aws-sdk/client-s3';
 import { getS3Config } from '../config/s3';
-import { randomUUID } from 'crypto';
+import { createHash } from 'crypto';
 
 /** Max size per PDF (e.g. annual reports with images). Kept in sync with multipart limit in app.ts. */
 export const PDF_MAX_BYTES = 400 * 1024 * 1024; // 400 MB per file
@@ -9,10 +9,21 @@ const PDF_MIME = 'application/pdf';
 
 let client: S3Client | null = null;
 
+function getTrimmedEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function getS3Endpoint(): string | undefined {
+  return getTrimmedEnv('S3_ENDPOINT');
+}
+
 function getClient(): S3Client {
   if (!client) {
     const { region } = getS3Config();
-    const endpoint = process.env.S3_ENDPOINT;
+    const endpoint = getS3Endpoint();
     const accessKeyId = process.env.S3_ACCESS_KEY_ID;
     const secretAccessKey = process.env.S3_SECRET_ACCESS_KEY;
     const sessionToken = process.env.S3_SESSION_TOKEN;
@@ -34,51 +45,109 @@ function getClient(): S3Client {
   return client;
 }
 
+export type PdfUploadResult = {
+  publicUrl: string;
+  bucket: string;
+  key: string;
+  sha256: string;
+  /** True if the object already existed and we reused it. */
+  reusedExisting: boolean;
+  /** True if we performed a PutObject in this request. */
+  uploaded: boolean;
+};
+
+function getUploadEnv(): string {
+  const nodeEnv = getTrimmedEnv('NODE_ENV');
+  if (nodeEnv === 'production') return 'prod';
+  if (nodeEnv === 'staging') return 'stage';
+  return 'dev';
+}
+
+function getPublicUrlForKey(params: { bucket: string; key: string }): string {
+  const { bucket, key } = params;
+  const publicBase = getTrimmedEnv('S3_PUBLIC_BASE_URL');
+  const endpoint = getS3Endpoint();
+
+  if (publicBase) {
+    return `${publicBase.replace(/\/$/, '')}/${key}`;
+  }
+  if (endpoint) {
+    const base = endpoint.replace(/\/$/, '');
+    return `${base}/${bucket}/${key}`;
+  }
+  throw new Error(
+    'Public URL is not configured. Set S3_PUBLIC_BASE_URL (e.g. https://storage.googleapis.com/<bucket>) or S3_ENDPOINT (e.g. https://storage.googleapis.com) so uploaded PDFs can be accessed later.'
+  );
+}
+
+function sha256Hex(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+async function objectExists(params: { bucket: string; key: string }): Promise<boolean> {
+  const s3 = getClient();
+  try {
+    await s3.send(
+      new HeadObjectCommand({
+        Bucket: params.bucket,
+        Key: params.key,
+      })
+    );
+    return true;
+  } catch (err: any) {
+    // AWS SDK v3 throws for 404/NotFound; treat those as "does not exist"
+    const httpStatus = err?.$metadata?.httpStatusCode;
+    const name = err?.name;
+    if (httpStatus === 404 || name === 'NotFound' || name === 'NoSuchKey') return false;
+    throw err;
+  }
+}
+
 /**
  * Upload PDF buffer to object storage and return a stable public URL.
- * Key format: uploads/YYYY-MM-DD/{uuid}.pdf
+ * Key format: uploads/{env}/{sha256}.pdf
+ *
+ * Semantics:
+ * - If an object with the same sha256 already exists in this env, we reuse it and return its URL.
+ * - Otherwise we upload and return the new URL.
  */
 export async function uploadPdfAndGetUrls(
   buffer: Buffer,
   filename?: string
-): Promise<{ publicUrl: string; bucket: string; key: string }> {
+): Promise<PdfUploadResult> {
   if (buffer.length > PDF_MAX_BYTES) {
     throw new Error(`PDF too large (max ${PDF_MAX_BYTES / 1024 / 1024} MB)`);
   }
 
   const { bucket } = getS3Config();
-  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  const ext = filename?.toLowerCase().endsWith('.pdf') ? '' : '.pdf';
-  const key = `uploads/${date}/${randomUUID()}${ext}`;
+  const env = getUploadEnv();
+  const sha256 = sha256Hex(buffer);
+  const key = `uploads/${env}/${sha256}.pdf`;
 
-  const s3 = getClient();
-  await s3.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      Body: buffer,
-      ContentType: PDF_MIME,
-    })
-  );
-
-  const publicBase = process.env.S3_PUBLIC_BASE_URL?.trim();
-  const endpoint = process.env.S3_ENDPOINT?.trim();
-
-  let publicUrl: string | undefined;
-  if (publicBase) {
-    publicUrl = `${publicBase.replace(/\/$/, '')}/${key}`;
-  } else if (endpoint) {
-    const base = endpoint.replace(/\/$/, '');
-    publicUrl = `${base}/${bucket}/${key}`;
-  }
-
-  if (!publicUrl) {
-    throw new Error(
-      'Public URL is not configured. Set S3_PUBLIC_BASE_URL (e.g. https://storage.googleapis.com/<bucket>) or S3_ENDPOINT (e.g. https://storage.googleapis.com) so uploaded PDFs can be accessed later.'
+  const existed = await objectExists({ bucket, key });
+  if (!existed) {
+    const s3 = getClient();
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: buffer,
+        ContentType: PDF_MIME,
+        // Keep a small trace for humans; not used for dedupe logic.
+        Metadata: filename ? { originalFilename: filename } : undefined,
+      })
     );
   }
 
-  return { publicUrl, bucket, key };
+  const publicUrl = getPublicUrlForKey({ bucket, key });
+  return {
+    publicUrl,
+    bucket,
+    key,
+    sha256,
+    reusedExisting: existed,
+    uploaded: !existed,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Improves how PDFs enter the `parsePdf` pipeline: uploads go to **content-addressed S3 keys** (with dedupe), optional **server-side fetch + cache** for URL-based jobs, **clearer API responses**, and **hardened outbound fetches** (timeouts, redirect limits, PDF validation, basic SSRF guards). The validation app is updated to match the new APIs and surface dedupe / cache feedback to users.

**Deploy:** Ship **`pipeline-api` and `validate` together** (or API first only if nothing else calls the changed endpoints yet).

---

## Changes

- **S3 uploads** (`S3UploadService`): Stable keys `uploads/{env}/{sha256}.pdf` with `{env}` from `NODE_ENV` (`prod` / `stage` / `dev`). **Head-then-put** dedupe; trimmed `S3_ENDPOINT` / `S3_PUBLIC_BASE_URL` for consistent URLs.
- **URL caching** (`PdfCacheService` + `POST …/parsePdf` with `cachePdf: true`): Fetches each URL, validates **PDF magic bytes**, uploads bytes to S3, enqueues job with **cached `url`** while preserving **`sourceUrl`** and **`pdfCache`** metadata on the job.
- **Outbound safety** (`outbound-pdf-url.ts`): `http`/`https` only, no URL userinfo, blocks common **private/reserved** targets (hostname + DNS-resolved IPs), **120s** overall timeout, **manual redirects** (capped), PDF header check after download.
- **Redis**: URL→entry cache with **14-day TTL** (`pdf:urlmap:…` only; redundant secondary key removed).
- **`POST …/parsePdf/upload`**: Response is **`{ jobs, uploads }`** with per-file **`reusedExisting` / `uploaded`** (breaking change for clients that expected a bare jobs array).
- **`POST …/parsePdf` with `cachePdf`**: **Per-URL try/catch** — partial success returns **200** with optional **`errors[]`**; **400** if every URL fails. OpenAPI schemas updated.
- **`QueueService.addJob`**: Merges **`options.data` first**, then sets **`url` / `id` / `autoApprove` last** so merged data cannot override the primary download URL.
- **Docs**: `docs/pdf-caching.md`, README (auth note, partial responses, env layout).

---

## What this provides

- **Less duplicate storage and bandwidth** for identical PDF bytes.
- **Stable worker inputs** from S3 when sources move or rate-limit.
- **Safer server-side URL fetch** than a raw `fetch` with unlimited redirects and no network bounds.
- **Clearer UX and errors** in Validate when dedupe or per-link cache fails.
- **Coordinated contract** between frontend and API for upload and link submission.
