### PR TITLE
Avoid per-job getState() Redis calls when bulk-fetching jobs

### DIFF
--- a/src/services/QueueService.ts
+++ b/src/services/QueueService.ts
@@ -87,17 +87,21 @@ export class QueueService {
     const jobs: BaseJob[] = [];
     for (const queueName of queueNames) {
       const queue = await this.getQueue(queueName);
-      const rawJobs = await queue.getJobs(queryStatus as JobType[]);
-      const filteredRawJobs = rawJobs.filter((job) => {
-        if (processId && job.data?.threadId !== processId) return false;
-        if (batchId != null && (job.data as any)?.batchId !== batchId)
-          return false;
-        return true;
-      });
-      const transformedJobs = await Promise.all(
-        filteredRawJobs.map((job) => transformJobtoBaseJob(job)),
-      );
-      jobs.push(...transformedJobs);
+      const counts = await queue.getJobCounts(...(queryStatus as JobType[]));
+      for (const status of queryStatus) {
+        if ((counts[status] ?? 0) === 0) continue;
+        const rawJobs = await queue.getJobs([status as JobType]);
+        const filteredRawJobs = rawJobs.filter((job) => {
+          if (processId && job.data?.threadId !== processId) return false;
+          if (batchId != null && (job.data as any)?.batchId !== batchId)
+            return false;
+          return true;
+        });
+        const transformedJobs = await Promise.all(
+          filteredRawJobs.map((job) => transformJobtoBaseJob(job, status)),
+        );
+        jobs.push(...transformedJobs);
+      }
     }
     return jobs;
   }
@@ -121,34 +125,38 @@ export class QueueService {
         const counts = await queue.getJobCounts(...(queryStatus as JobType[]));
         if (Object.values(counts).every((c) => c === 0)) return [];
 
-        // Paginate instead of fetching all
+        // Fetch one status at a time so we know each job's state without calling getState()
         const PAGE_SIZE = 100;
-        let start = 0;
-        const rawJobs: Job[] = [];
+        const rawJobsWithState: Array<{ job: Job; state: string }> = [];
 
-        while (true) {
-          const page = await queue.getJobs(
-            queryStatus as JobType[],
-            start,
-            start + PAGE_SIZE - 1,
-          );
-          if (page.length === 0) break;
+        for (const status of queryStatus) {
+          if ((counts[status] ?? 0) === 0) continue;
 
-          const filtered = page.filter((job) => {
-            if (processId && job.data?.threadId !== processId) return false;
-            if (batchId != null && (job.data as any)?.batchId !== batchId)
-              return false;
-            return true;
-          });
+          let start = 0;
+          while (true) {
+            const page = await queue.getJobs(
+              [status as JobType],
+              start,
+              start + PAGE_SIZE - 1,
+            );
+            if (page.length === 0) break;
 
-          rawJobs.push(...filtered);
-          if (page.length < PAGE_SIZE) break;
-          start += PAGE_SIZE;
+            const filtered = page.filter((job) => {
+              if (processId && job.data?.threadId !== processId) return false;
+              if (batchId != null && (job.data as any)?.batchId !== batchId)
+                return false;
+              return true;
+            });
+
+            rawJobsWithState.push(...filtered.map((job) => ({ job, state: status })));
+            if (page.length < PAGE_SIZE) break;
+            start += PAGE_SIZE;
+          }
         }
 
         return Promise.all(
-          rawJobs.map(async (job) => {
-            const dataJob: DataJob = await transformJobtoBaseJob(job);
+          rawJobsWithState.map(async ({ job, state }) => {
+            const dataJob: DataJob = await transformJobtoBaseJob(job, state);
             dataJob.data = job.data;
             dataJob.returnvalue = job.returnvalue;
             return dataJob;
@@ -1029,7 +1037,7 @@ export class QueueService {
   }
 }
 
-export async function transformJobtoBaseJob(job: Job): Promise<BaseJob> {
+export async function transformJobtoBaseJob(job: Job, knownState?: string): Promise<BaseJob> {
   return {
     name: job.name,
     queue: job.queueName,
@@ -1048,6 +1056,6 @@ export async function transformJobtoBaseJob(job: Job): Promise<BaseJob> {
     progress: typeof job.progress === "number" ? job.progress : undefined,
     opts: job.opts,
     delay: job.delay,
-    status: (await job.getState()) as JobType,
+    status: (knownState ?? await job.getState()) as JobType,
   };
 }


### PR DESCRIPTION
## Summary

- `transformJobtoBaseJob` now accepts an optional `knownState` parameter, skipping the `job.getState()` Redis call when the caller already knows the status
- `getJobs` and `getDataJobs` now fetch one status at a time (instead of all statuses mixed), so the state is always known — eliminating one Redis round-trip per job
- Empty statuses are skipped via `getJobCounts` before fetching

## Motivation

Loading `/processes/companies` was getting very slow past ~40 companies because the old code called `job.getState()` individually for every job across all queues — potentially thousands of extra Redis round-trips per request.

## Uncertainty

This should help significantly, but it's worth measuring response times before/after to confirm it's the dominant bottleneck vs. other factors (data volume, number of queues, etc).