### PR TITLE
[Change]: Modified BullMQ TTL

### DIFF
--- a/src/lib/bullmq.ts
+++ b/src/lib/bullmq.ts
@@ -62,11 +62,9 @@ async function startQueues() {
       new Queue(name, {
         connection: redis,
         defaultJobOptions: {
-          removeOnComplete: {
-            age: 2_419_200, // 4 weeks in seconds
-          },
+          removeOnComplete: true,
           removeOnFail: {
-            age: 2_419_200, // 4 weeks in seconds
+            age: 1_209_600, // 2 weeks in seconds
           },
         },
       }),


### PR DESCRIPTION
**Queue job retention:**
- Changed `removeOnComplete` in BullMQ queue configuration to `true` (immediate removal), and reduced the `removeOnFail` retention period from 4 weeks to 2 weeks.