### PR TITLE
[Change]: Modified TTL

### DIFF
--- a/src/lib/bullmq.ts
+++ b/src/lib/bullmq.ts
@@ -62,7 +62,9 @@ async function startQueues() {
       new Queue(name, {
         connection: redis,
         defaultJobOptions: {
-          removeOnComplete: true,
+          removeOnComplete: {
+            age: 7_200, // 2 hours in seconds
+          },
           removeOnFail: {
             age: 1_209_600, // 2 weeks in seconds
           },


### PR DESCRIPTION
This pull request makes a small but important change to how completed jobs are retained in BullMQ queues. Instead of removing completed jobs immediately, they are now kept for 2 hours before being deleted.

* Updated the `removeOnComplete` option in the BullMQ queue configuration in `src/lib/bullmq.ts` to keep completed jobs for 2 hours before removal, instead of removing them immediately.