### PR TITLE
Add extractLEI queue to QUEUE_NAMES

### DIFF
--- a/src/lib/bullmq.ts
+++ b/src/lib/bullmq.ts
@@ -51,6 +51,7 @@ export const QUEUE_NAMES = {
   DIFF_INITIATIVES: "diffInitiatives",
   DIFF_REPORTING_PERIODS: "diffReportingPeriods",
   DIFF_TAGS: "diffTags",
+  EXTRACT_LEI: "extractLEI",
   SAVE_TO_API: "saveToAPI",
   SEND_COMPANY_LINK: "sendCompanyLink",
   WIKIPEDIA_UPLOAD: "wikipediaUpload",


### PR DESCRIPTION
## Summary
- Registers `extractLEI` in `QUEUE_NAMES` so it is included in all bulk queue fetches
- Without this, the queue was invisible to the API — jobs wouldn't appear in the company swimlane or stats endpoints

## Test plan
- [ ] Verify `extractLEI` jobs appear in the swimlane after the queue has jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)