### PR TITLE
[FIX] add new cache pdf route for registry

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import apiConfig from './config/api'
 import { readQueuesRoute } from './routes/readQueues'
+import { cachePdfRoute } from './routes/cachePdf'
 import { jsonSchemaTransform, serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod'
 import { z } from 'zod'
 import { readProcessRoute } from './routes/readProcess'
@@ -69,11 +70,12 @@ async function startApp() {
     const writeMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
     const isWriteOperation = writeMethods.includes(method);
     
-    // Protected route patterns (queues, processes, pipeline)
+    // Protected route patterns (queues, processes, pipeline, cache-pdf)
     const protectedRoutePatterns = [
       '/api/queues',
       '/api/processes',
       '/api/pipeline',
+      '/api/cache-pdf',
     ];
     
     // Check if this is a public endpoint
@@ -129,6 +131,9 @@ async function startApp() {
     }
   });
 
+  app.register(cachePdfRoute, {
+    prefix: '/api/cache-pdf',
+  })
   app.register(readQueuesRoute, {
     prefix: '/api/queues',
   })

--- a/src/routes/cachePdf.ts
+++ b/src/routes/cachePdf.ts
@@ -1,0 +1,54 @@
+import { FastifyInstance, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { cachePdfFromUrl } from "../services/PdfCacheService";
+import { isS3Configured } from "../config/s3";
+
+const cachePdfBodySchema = z.object({
+  url: z.string().url("url must be a valid URL"),
+});
+
+const cachePdfResponseSchema = z.object({
+  env: z.string(),
+  sourceUrl: z.string().url(),
+  sha256: z.string(),
+  bucket: z.string(),
+  key: z.string(),
+  publicUrl: z.string().url(),
+  reusedExisting: z.boolean(),
+  uploaded: z.boolean(),
+  fetchedAt: z.string(),
+  contentLength: z.number().optional(),
+});
+
+export async function cachePdfRoute(app: FastifyInstance) {
+  app.post(
+    "/",
+    {
+      schema: {
+        summary: "Cache a PDF to S3",
+        description:
+          "Fetch a PDF from the given URL, upload it to S3, and return the stable S3 URL and metadata. Reuses an existing cached copy if the same source URL was previously cached.",
+        tags: ["PDF"],
+        body: cachePdfBodySchema,
+        response: {
+          200: cachePdfResponseSchema,
+          503: z.object({ error: z.string() }),
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{ Body: { url: string } }>,
+      reply,
+    ) => {
+      if (!isS3Configured()) {
+        return reply.status(503).send({
+          error: "PDF caching is not configured. Set S3_BUCKET in the environment.",
+        });
+      }
+
+      const { url } = request.body;
+      const entry = await cachePdfFromUrl(url);
+      return reply.send(entry);
+    },
+  );
+}


### PR DESCRIPTION
Set up new cachepdf endpoint that does not auto trigger pipeline for the registry