### PR TITLE
[Change]: Modified TTL to count instead of time

### DIFF
--- a/src/lib/bullmq.ts
+++ b/src/lib/bullmq.ts
@@ -64,7 +64,7 @@ async function startQueues() {
         connection: redis,
         defaultJobOptions: {
           removeOnComplete: {
-            age: 7_200, // 2 hours in seconds
+            count: 30,
           },
           removeOnFail: {
             age: 1_209_600, // 2 weeks in seconds


### PR DESCRIPTION
This pull request makes a small update to the BullMQ queue configuration by changing the job cleanup policy. Instead of removing completed jobs after a certain age, the queue will now retain only the most recent 30 completed jobs.

- Updated the `removeOnComplete` option in the BullMQ queue configuration within `src/lib/bullmq.ts` to keep a maximum of 30 completed jobs, instead of removing based on job age.