### PR TITLE
Increase memory requests and limits

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -20,10 +20,10 @@ spec:
           image: ghcr.io/klimatbyran/pipeline-api
           resources:
             requests:
-              memory: "512Mi"
+              memory: "768Mi"
               cpu: "250m"
             limits:
-              memory: "1280Mi"
+              memory: "2Gi"
               cpu: "500m"
           ports:
             - containerPort: 4000


### PR DESCRIPTION
## Summary
- Bumps memory **requests** from 512Mi → 768Mi
- Bumps memory **limits** from 1280Mi → 2Gi
- Maintains the same ~2.5x request/limit ratio
- CPU unchanged

## Test plan
- [ ] Deploy to staging and verify pods start without OOMKilled events

🤖 Generated with [Claude Code](https://claude.com/claude-code)