### PR TITLE
Wire INTERNAL_SERVICE_TOKEN into pipeline-api deployment

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -70,3 +70,8 @@ spec:
                 secretKeyRef:
                   name: env
                   key: NODE_ENV
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: env
+                  key: INTERNAL_SERVICE_TOKEN


### PR DESCRIPTION
## Summary
- Add `INTERNAL_SERVICE_TOKEN` from the `env` secret to the pipeline-api deployment so `/api/internal/prune-runs` is usable by garbo workers.

## Test plan
- [x] `INTERNAL_SERVICE_TOKEN` added to `garbo-stage` env secret
- [ ] After deploy, `POST /api/internal/prune-runs` returns 401 without token (not 503)
- [ ] Garbo worker can trigger prune after run completion


Made with [Cursor](https://cursor.com)