### PR TITLE
Align queue defaults with run-level Redis retention

### DIFF
--- a/src/lib/bullmq.ts
+++ b/src/lib/bullmq.ts
@@ -63,10 +63,8 @@ export const QUEUE_NAMES = {
 };
 
 export const DEFAULT_PIPELINE_JOB_OPTIONS = {
-  // Overflow safety net only — run-level pruning is authoritative.
-  removeOnComplete: {
-    count: 30,
-  },
+  // Eviction is run-level (RunRetentionService / prune-runs), not per-queue.
+  removeOnComplete: false,
   removeOnFail: {
     age: 1_209_600, // 2 weeks in seconds
   },


### PR DESCRIPTION
## Summary
- Disable per-queue `removeOnComplete: { count: 30 }` on pipeline queue defaults.
- Eviction is handled by `RunRetentionService` (15 most recent runs) and the daily prune cron.

## Problem
Per-queue eviction conflicted with run-level retention and caused `saveToAPI` jobs to disappear from live Jobbstatus while their run was still protected. Pairs with garbo PR for the same fix.

## Test plan
- [ ] Deploy alongside garbo retention fix
- [ ] `npm run prune-runs-by-company -- --dry-run` still selects runs beyond keep count
- [ ] Live Jobbstatus shows stable green `saveToAPI` for recent completed runs


Made with [Cursor](https://cursor.com)