### PR TITLE
[Prod] Patch Version Bump v0.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipeline-status",
-  "version": "0.4.4-rc.1",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pipeline-status",
-      "version": "0.4.4-rc.1",
+      "version": "0.4.4",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1002.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-status",
-  "version": "0.4.4-rc.1",
+  "version": "0.4.4",
   "scripts": {
     "build": "tsc",
     "start": "node --max-old-space-size=4096 --import tsx src/index.ts",


### PR DESCRIPTION
## Summary

Patch production release **v0.4.4** (rollback: **v0.4.3**).

## What's being released

- Disable per-queue completed job eviction in favor of run-level Redis pruning (#76)
- Fixes validate job status showing grey for `saveToAPI` when earlier per-queue eviction removed completed jobs

## Deployment notes

- Deploy together with **Garbo v6.0.6** (matching retention behaviour)
- No DB migrations

## Test plan

- [ ] Run a report through the pipeline in staging
- [ ] Validate job status shows correct latest `saveToAPI` state (not stale grey)
- [ ] Completed runs still prune via run-level retention as expected


Made with [Cursor](https://cursor.com)