### PR TITLE
Pass company identity into parsePdf enqueue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "node --max-old-space-size=4096 --import tsx --watch src/index.ts",
     "clean-old-bullmq": "node --max-old-space-size=512 --import tsx scripts/clean-old-bullmq.ts",
     "prune-runs-by-company": "node --max-old-space-size=512 --import tsx scripts/prune-runs-by-company.ts",
-    "test": "node --import tsx --test src/lib/runRetention.test.ts"
+    "test": "node --import tsx --test src/lib/runRetention.test.ts src/lib/pipelineCompanyJobData.test.ts"
   },
   "author": "Christian Landgren, Moritz Zingg et al.",
   "license": "ISC",

--- a/src/lib/pipelineCompanyJobData.test.ts
+++ b/src/lib/pipelineCompanyJobData.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  companyJobDataForUrl,
+  mergeJobDataWithCompanyContext,
+} from './pipelineCompanyJobData.js'
+
+describe('pipelineCompanyJobData', () => {
+  it('merges per-url context into job data', () => {
+    assert.deepEqual(
+      companyJobDataForUrl('https://example.com/a.pdf', {
+        urlContexts: [
+          {
+            url: 'https://example.com/a.pdf',
+            companyId: '11111111-1111-4111-8111-111111111111',
+            companyName: 'Meta',
+            wikidataId: 'Q380',
+          },
+        ],
+      }),
+      {
+        companyId: '11111111-1111-4111-8111-111111111111',
+        companyName: 'Meta',
+        wikidata: { node: 'Q380' },
+      }
+    )
+  })
+
+  it('falls back to pipelineCompany for all urls', () => {
+    assert.deepEqual(
+      mergeJobDataWithCompanyContext(
+        { sourceUrl: 'https://example.com/a.pdf' },
+        'https://example.com/a.pdf',
+        {
+          pipelineCompany: { wikidataId: 'Q380' },
+        }
+      ),
+      {
+        sourceUrl: 'https://example.com/a.pdf',
+        wikidata: { node: 'Q380' },
+      }
+    )
+  })
+
+  it('prefers per-url context over pipelineCompany', () => {
+    assert.deepEqual(
+      companyJobDataForUrl('https://example.com/a.pdf', {
+        pipelineCompany: { wikidataId: 'Q1' },
+        urlContexts: [{ url: 'https://example.com/a.pdf', wikidataId: 'Q380' }],
+      }),
+      {
+        wikidata: { node: 'Q380' },
+      }
+    )
+  })
+})

--- a/src/lib/pipelineCompanyJobData.ts
+++ b/src/lib/pipelineCompanyJobData.ts
@@ -1,0 +1,37 @@
+import type { AddJobBody } from '../schemas/types'
+
+export type PipelineCompanyContext = {
+  companyId?: string
+  companyName?: string
+  wikidataId?: string
+}
+
+/** Per-URL company identity passed from Validate into parsePdf job data. */
+export function companyJobDataForUrl(
+  url: string,
+  body: Pick<AddJobBody, 'urlContexts' | 'pipelineCompany'>
+): Record<string, unknown> {
+  const perUrl = body.urlContexts?.find((ctx) => ctx.url === url)
+  const ctx = perUrl ?? body.pipelineCompany
+  if (!ctx) return {}
+
+  const data: Record<string, unknown> = {}
+  if (ctx.companyId?.trim()) {
+    data.companyId = ctx.companyId.trim()
+  }
+  if (ctx.companyName?.trim()) {
+    data.companyName = ctx.companyName.trim()
+  }
+  if (ctx.wikidataId?.trim()) {
+    data.wikidata = { node: ctx.wikidataId.trim() }
+  }
+  return data
+}
+
+export function mergeJobDataWithCompanyContext(
+  base: Record<string, unknown>,
+  url: string,
+  body: Pick<AddJobBody, 'urlContexts' | 'pipelineCompany'>
+): Record<string, unknown> {
+  return { ...base, ...companyJobDataForUrl(url, body) }
+}

--- a/src/routes/readQueues.ts
+++ b/src/routes/readQueues.ts
@@ -1,16 +1,16 @@
-import { FastifyInstance, FastifyRequest } from "fastify";
-import { randomUUID } from "crypto";
-import { QueueService } from "../services/QueueService";
-import { AddJobBody, BaseJob } from "../schemas/types";
+import { FastifyInstance, FastifyRequest } from 'fastify'
+import { randomUUID } from 'crypto'
+import { QueueService } from '../services/QueueService'
+import { AddJobBody, BaseJob } from '../schemas/types'
 import {
   error404ResponseSchema,
   queueAddJobResponseSchema,
   queueJobResponseSchema,
   queueResponseSchema,
   queueStatsResponseSchema,
-} from "../schemas/response";
-import { STATUS, QUEUE_NAMES } from "../lib/bullmq";
-import { JobType } from "bullmq";
+} from '../schemas/response'
+import { STATUS, QUEUE_NAMES } from '../lib/bullmq'
+import { JobType } from 'bullmq'
 import {
   addQueueJobBodySchema,
   readQueueJobPathParamsSchema,
@@ -20,18 +20,19 @@ import {
   rerunAndSaveQueueJobBodySchema,
   rerunJobsByWorkerBodySchema,
   rerunQueueJobBodySchema,
-} from "../schemas/request";
-import { z } from "zod";
+} from '../schemas/request'
+import { z } from 'zod'
 import {
   type PdfUploadResult,
   uploadPdfAndGetUrls,
-} from "../services/S3UploadService";
-import { isS3Configured } from "../config/s3";
+} from '../services/S3UploadService'
+import { isS3Configured } from '../config/s3'
 import {
   cachePdfFromUrl,
   type PdfCacheEntry,
-} from "../services/PdfCacheService";
-import { withUrlReportYearForDisplay } from "../lib/documentReportYear";
+} from '../services/PdfCacheService'
+import { withUrlReportYearForDisplay } from '../lib/documentReportYear'
+import { mergeJobDataWithCompanyContext } from '../lib/pipelineCompanyJobData'
 
 const pdfUploadMetaSchema = z.object({
   filename: z.string(),
@@ -41,7 +42,7 @@ const pdfUploadMetaSchema = z.object({
   sha256: z.string(),
   reusedExisting: z.boolean(),
   uploaded: z.boolean(),
-});
+})
 
 const pdfCacheEntrySchema = z.object({
   env: z.string(),
@@ -54,52 +55,52 @@ const pdfCacheEntrySchema = z.object({
   uploaded: z.boolean(),
   fetchedAt: z.string(),
   contentLength: z.number().optional(),
-});
+})
 
 const pdfCacheUrlErrorSchema = z.object({
   url: z.string(),
   error: z.string(),
-});
+})
 
 async function uploadAndEnqueueParsePdfJobs(params: {
-  queueService: QueueService;
-  files: { buffer: Buffer; filename: string }[];
+  queueService: QueueService
+  files: { buffer: Buffer; filename: string }[]
   options: {
-    autoApprove?: boolean;
-    batchId?: string;
-    forceReindex?: boolean;
-    replaceAllEmissions?: boolean;
-    runOnly?: string[];
-    tags?: string[];
-  };
-  request: FastifyRequest;
-  fileTooLargeMessage: string;
+    autoApprove?: boolean
+    batchId?: string
+    forceReindex?: boolean
+    replaceAllEmissions?: boolean
+    runOnly?: string[]
+    tags?: string[]
+  }
+  request: FastifyRequest
+  fileTooLargeMessage: string
 }): Promise<
   | {
-      ok: true;
-      jobs: BaseJob[];
-      uploads: Array<{ filename: string } & PdfUploadResult>;
+      ok: true
+      jobs: BaseJob[]
+      uploads: Array<{ filename: string } & PdfUploadResult>
     }
   | { ok: false; status: 413 | 500; error: string }
 > {
-  const { queueService, files, options, request, fileTooLargeMessage } = params;
+  const { queueService, files, options, request, fileTooLargeMessage } = params
 
-  const addedJobs: BaseJob[] = [];
-  const uploads: Array<{ filename: string } & PdfUploadResult> = [];
+  const addedJobs: BaseJob[] = []
+  const uploads: Array<{ filename: string } & PdfUploadResult> = []
   for (const { buffer, filename } of files) {
-    let upload: PdfUploadResult;
+    let upload: PdfUploadResult
     try {
-      upload = await uploadPdfAndGetUrls(buffer, filename);
+      upload = await uploadPdfAndGetUrls(buffer, filename)
     } catch (err: any) {
-      request.log.warn({ err, filename }, "S3 upload failed");
-      const isTooLarge = err?.message?.includes("too large") ?? false;
+      request.log.warn({ err, filename }, 'S3 upload failed')
+      const isTooLarge = err?.message?.includes('too large') ?? false
       return {
         ok: false,
         status: isTooLarge ? 413 : 500,
         error: isTooLarge
           ? fileTooLargeMessage
-          : (err?.message ?? "Failed to upload PDF to storage."),
-      };
+          : (err?.message ?? 'Failed to upload PDF to storage.'),
+      }
     }
 
     request.log.info(
@@ -109,10 +110,10 @@ async function uploadAndEnqueueParsePdfJobs(params: {
         reusedExisting: upload.reusedExisting,
         uploaded: upload.uploaded,
       },
-      "S3 upload succeeded, adding to BullMQ",
-    );
-    uploads.push({ filename, ...upload });
-    const perUrlThreadId = randomUUID();
+      'S3 upload succeeded, adding to BullMQ'
+    )
+    uploads.push({ filename, ...upload })
+    const perUrlThreadId = randomUUID()
     const addedJob = await queueService.addJob(
       QUEUE_NAMES.PARSE_PDF,
       upload.publicUrl,
@@ -136,103 +137,103 @@ async function uploadAndEnqueueParsePdfJobs(params: {
               uploaded: upload.uploaded,
             },
           },
-          `uploaded:${filename}`,
+          `uploaded:${filename}`
         ),
-      },
-    );
+      }
+    )
     request.log.info(
       { filename, jobId: addedJob.id },
-      "BullMQ job added successfully",
-    );
-    addedJobs.push(addedJob);
+      'BullMQ job added successfully'
+    )
+    addedJobs.push(addedJob)
   }
 
-  return { ok: true, jobs: addedJobs, uploads };
+  return { ok: true, jobs: addedJobs, uploads }
 }
 
 async function parseParsePdfUpload(request: FastifyRequest): Promise<{
   options: {
-    autoApprove?: boolean;
-    batchId?: string;
-    forceReindex?: boolean;
-    replaceAllEmissions?: boolean;
-    runOnly?: string[];
-    tags?: string[];
-  };
-  files: { buffer: Buffer; filename: string }[];
+    autoApprove?: boolean
+    batchId?: string
+    forceReindex?: boolean
+    replaceAllEmissions?: boolean
+    runOnly?: string[]
+    tags?: string[]
+  }
+  files: { buffer: Buffer; filename: string }[]
 }> {
   const options: {
-    autoApprove?: boolean;
-    batchId?: string;
-    forceReindex?: boolean;
-    replaceAllEmissions?: boolean;
-    runOnly?: string[];
-    tags?: string[];
-  } = {};
+    autoApprove?: boolean
+    batchId?: string
+    forceReindex?: boolean
+    replaceAllEmissions?: boolean
+    runOnly?: string[]
+    tags?: string[]
+  } = {}
 
-  const files: { buffer: Buffer; filename: string }[] = [];
+  const files: { buffer: Buffer; filename: string }[] = []
 
-  const parts = (request as any).parts();
+  const parts = (request as any).parts()
   for await (const part of parts) {
-    if (part.type === "field") {
-      const raw = part.value;
-      const value = typeof raw === "string" ? raw : String(raw ?? "");
+    if (part.type === 'field') {
+      const raw = part.value
+      const value = typeof raw === 'string' ? raw : String(raw ?? '')
 
       switch (part.fieldname) {
-        case "autoApprove":
-          options.autoApprove = value === "true" || value === "1";
-          break;
-        case "batchId": {
+        case 'autoApprove':
+          options.autoApprove = value === 'true' || value === '1'
+          break
+        case 'batchId': {
           const s =
-            typeof raw === "string"
+            typeof raw === 'string'
               ? raw
               : raw == null
                 ? undefined
-                : String(raw);
-          options.batchId = s ?? undefined;
-          break;
+                : String(raw)
+          options.batchId = s ?? undefined
+          break
         }
-        case "forceReindex":
-          options.forceReindex = value === "true" || value === "1";
-          break;
-        case "replaceAllEmissions":
-          options.replaceAllEmissions = value === "true" || value === "1";
-          break;
-        case "runOnly":
+        case 'forceReindex':
+          options.forceReindex = value === 'true' || value === '1'
+          break
+        case 'replaceAllEmissions':
+          options.replaceAllEmissions = value === 'true' || value === '1'
+          break
+        case 'runOnly':
           try {
-            options.runOnly = value ? JSON.parse(value) : undefined;
+            options.runOnly = value ? JSON.parse(value) : undefined
           } catch {
             /* ignore invalid JSON */
           }
-          break;
-        case "tags":
+          break
+        case 'tags':
           try {
-            options.tags = value ? JSON.parse(value) : undefined;
+            options.tags = value ? JSON.parse(value) : undefined
           } catch {
             /* ignore invalid JSON */
           }
-          break;
+          break
       }
-    } else if (part.type === "file") {
-      const buffer = await part.toBuffer();
-      const filename = part.filename ?? "report.pdf";
+    } else if (part.type === 'file') {
+      const buffer = await part.toBuffer()
+      const filename = part.filename ?? 'report.pdf'
       if (buffer.length > 0) {
-        files.push({ buffer, filename });
+        files.push({ buffer, filename })
       }
     }
   }
 
-  return { options, files };
+  return { options, files }
 }
 
 export async function readQueuesRoute(app: FastifyInstance) {
   app.get(
-    "/",
+    '/',
     {
       schema: {
-        summary: "Get jobs",
-        description: "",
-        tags: ["Queues"],
+        summary: 'Get jobs',
+        description: '',
+        tags: ['Queues'],
         querystring: readQueueQueryStringSchema,
         response: {
           200: queueResponseSchema,
@@ -241,24 +242,24 @@ export async function readQueuesRoute(app: FastifyInstance) {
     },
     async (
       request: FastifyRequest<{
-        Querystring: { status?: STATUS };
+        Querystring: { status?: STATUS }
       }>,
-      reply,
+      reply
     ) => {
-      const { status } = request.query;
-      const queueService = await QueueService.getQueueService();
-      const jobs = await queueService.getJobs([], status);
-      return reply.send(jobs);
-    },
-  );
+      const { status } = request.query
+      const queueService = await QueueService.getQueueService()
+      const jobs = await queueService.getJobs([], status)
+      return reply.send(jobs)
+    }
+  )
 
   app.get(
-    "/:name",
+    '/:name',
     {
       schema: {
-        summary: "Get jobs in requested queue",
-        description: "",
-        tags: ["Queues"],
+        summary: 'Get jobs in requested queue',
+        description: '',
+        tags: ['Queues'],
         params: readQueuePathParamsSchema,
         querystring: readQueueQueryStringSchema,
         response: {
@@ -268,29 +269,29 @@ export async function readQueuesRoute(app: FastifyInstance) {
     },
     async (
       request: FastifyRequest<{
-        Params: { name: string };
-        Querystring: { status?: STATUS };
+        Params: { name: string }
+        Querystring: { status?: STATUS }
       }>,
-      reply,
+      reply
     ) => {
-      const { name } = request.params;
-      const { status } = request.query;
-      const queueService = await QueueService.getQueueService();
-      const jobs = await queueService.getJobs([name], status);
-      return reply.send(jobs);
-    },
-  );
+      const { name } = request.params
+      const { status } = request.query
+      const queueService = await QueueService.getQueueService()
+      const jobs = await queueService.getJobs([name], status)
+      return reply.send(jobs)
+    }
+  )
 
   // File upload for parsePdf: must be registered before POST /:name so path parsePdf/upload is matched
   app.post(
-    "/parsePdf/upload",
+    '/parsePdf/upload',
     {
       schema: {
-        summary: "Upload PDFs and add parsePdf jobs",
+        summary: 'Upload PDFs and add parsePdf jobs',
         description:
-          "Accept multipart/form-data with PDF files and optional options (autoApprove, batchId, forceReindex, replaceAllEmissions, runOnly, tags). Same job shape as URL-based POST /queues/parsePdf. Requires S3_BUCKET to be set.",
-        tags: ["Queues"],
-        consumes: ["multipart/form-data"],
+          'Accept multipart/form-data with PDF files and optional options (autoApprove, batchId, forceReindex, replaceAllEmissions, runOnly, tags). Same job shape as URL-based POST /queues/parsePdf. Requires S3_BUCKET to be set.',
+        tags: ['Queues'],
+        consumes: ['multipart/form-data'],
         response: {
           200: z.object({
             jobs: queueAddJobResponseSchema,
@@ -307,38 +308,36 @@ export async function readQueuesRoute(app: FastifyInstance) {
       if (!isS3Configured()) {
         return reply.status(503).send({
           error:
-            "PDF upload is not configured. Set S3_BUCKET in the environment.",
-        });
+            'PDF upload is not configured. Set S3_BUCKET in the environment.',
+        })
       }
       const FILE_TOO_LARGE_MSG =
-        "File too large. Maximum size is 400 MB per file.";
-      const queueService = await QueueService.getQueueService();
+        'File too large. Maximum size is 400 MB per file.'
+      const queueService = await QueueService.getQueueService()
       let options: {
-        autoApprove?: boolean;
-        batchId?: string;
-        forceReindex?: boolean;
-        replaceAllEmissions?: boolean;
-        runOnly?: string[];
-        tags?: string[];
-      };
-      let files: { buffer: Buffer; filename: string }[];
+        autoApprove?: boolean
+        batchId?: string
+        forceReindex?: boolean
+        replaceAllEmissions?: boolean
+        runOnly?: string[]
+        tags?: string[]
+      }
+      let files: { buffer: Buffer; filename: string }[]
 
       try {
-        ({ options, files } = await parseParsePdfUpload(request));
+        ;({ options, files } = await parseParsePdfUpload(request))
       } catch (err: any) {
-        if (err?.statusCode === 413 || err?.code === "FST_REQ_FILE_TOO_LARGE") {
-          return reply.status(413).send({ error: FILE_TOO_LARGE_MSG });
+        if (err?.statusCode === 413 || err?.code === 'FST_REQ_FILE_TOO_LARGE') {
+          return reply.status(413).send({ error: FILE_TOO_LARGE_MSG })
         }
-        throw err;
+        throw err
       }
 
       if (files.length === 0) {
-        return reply
-          .status(400)
-          .send({
-            error:
-              "At least one PDF file is required (multipart field name: file or files).",
-          });
+        return reply.status(400).send({
+          error:
+            'At least one PDF file is required (multipart field name: file or files).',
+        })
       }
 
       const uploadResult = await uploadAndEnqueueParsePdfJobs({
@@ -347,36 +346,36 @@ export async function readQueuesRoute(app: FastifyInstance) {
         options,
         request,
         fileTooLargeMessage: FILE_TOO_LARGE_MSG,
-      });
+      })
       if (!uploadResult.ok) {
         return reply
           .status(uploadResult.status)
-          .send({ error: uploadResult.error });
+          .send({ error: uploadResult.error })
       }
 
       app.log.info(
         {
-          queue: "parsePdf",
+          queue: 'parsePdf',
           uploadCount: files.length,
           ...options,
         },
-        "ParsePdf upload request completed",
-      );
+        'ParsePdf upload request completed'
+      )
       return reply.send({
         jobs: uploadResult.jobs,
         uploads: uploadResult.uploads,
-      });
-    },
-  );
+      })
+    }
+  )
 
   app.post(
-    "/:name",
+    '/:name',
     {
       schema: {
-        summary: "Add job to a queue",
+        summary: 'Add job to a queue',
         description:
-          "Enqueue one or more URLs into the specified queue. Optional flags include autoApprove, replaceAllEmissions and forceReindex (alias: force-reindex). For parsePdf only: set cachePdf=true to cache PDFs to S3 before enqueueing so workers read from storage.",
-        tags: ["Queues"],
+          'Enqueue one or more URLs into the specified queue. Optional flags include autoApprove, replaceAllEmissions and forceReindex (alias: force-reindex). For parsePdf only: set cachePdf=true to cache PDFs to S3 before enqueueing so workers read from storage.',
+        tags: ['Queues'],
         params: readQueuePathParamsSchema,
         body: addQueueJobBodySchema,
         response: {
@@ -397,21 +396,19 @@ export async function readQueuesRoute(app: FastifyInstance) {
     },
     async (
       request: FastifyRequest<{
-        Params: { name: string };
-        Body: AddJobBody;
+        Params: { name: string }
+        Body: AddJobBody
       }>,
-      reply,
+      reply
     ) => {
-      const { name } = request.params;
+      const { name } = request.params
       const resolvedName = Object.values(QUEUE_NAMES).find(
-        (q) => q.toLowerCase() === name.toLowerCase(),
-      );
+        (q) => q.toLowerCase() === name.toLowerCase()
+      )
       if (!resolvedName) {
-        return reply
-          .status(400)
-          .send({
-            error: `Unknown queue '${name}'. Valid queues: ${Object.values(QUEUE_NAMES).join(", ")}`,
-          });
+        return reply.status(400).send({
+          error: `Unknown queue '${name}'. Valid queues: ${Object.values(QUEUE_NAMES).join(', ')}`,
+        })
       }
       const {
         urls,
@@ -423,7 +420,10 @@ export async function readQueuesRoute(app: FastifyInstance) {
         tags,
         cachePdf,
         callbackUrl,
-      } = request.body;
+        pipelineCompany,
+        urlContexts,
+      } = request.body
+      const companyContextBody = { pipelineCompany, urlContexts }
       // Log enqueue request (sanitized)
       app.log.info(
         {
@@ -437,24 +437,24 @@ export async function readQueuesRoute(app: FastifyInstance) {
           tags: tags ?? undefined,
           cachePdf: !!cachePdf,
         },
-        "Enqueue request received",
-      );
-      const queueService = await QueueService.getQueueService();
-      const addedJobs: BaseJob[] = [];
-      const cached: PdfCacheEntry[] = [];
-      const cacheErrors: Array<{ url: string; error: string }> = [];
+        'Enqueue request received'
+      )
+      const queueService = await QueueService.getQueueService()
+      const addedJobs: BaseJob[] = []
+      const cached: PdfCacheEntry[] = []
+      const cacheErrors: Array<{ url: string; error: string }> = []
 
       for (const url of urls) {
         if (resolvedName === QUEUE_NAMES.PARSE_PDF && cachePdf) {
           if (!isS3Configured()) {
             return reply.status(503).send({
               error:
-                "PDF caching is not configured. Set S3_BUCKET in the environment.",
-            });
+                'PDF caching is not configured. Set S3_BUCKET in the environment.',
+            })
           }
           try {
-            const entry = await cachePdfFromUrl(url);
-            const perUrlThreadId = randomUUID();
+            const entry = await cachePdfFromUrl(url)
+            const perUrlThreadId = randomUUID()
             const addedJob = await queueService.addJob(
               resolvedName,
               entry.publicUrl,
@@ -467,34 +467,38 @@ export async function readQueuesRoute(app: FastifyInstance) {
                 batchId,
                 tags,
                 data: withUrlReportYearForDisplay(
-                  {
-                    sourceUrl: url,
-                    pdfCache: {
-                      sha256: entry.sha256,
-                      bucket: entry.bucket,
-                      key: entry.key,
-                      publicUrl: entry.publicUrl,
-                      reusedExisting: entry.reusedExisting,
-                      uploaded: entry.uploaded,
-                      fetchedAt: entry.fetchedAt,
+                  mergeJobDataWithCompanyContext(
+                    {
+                      sourceUrl: url,
+                      pdfCache: {
+                        sha256: entry.sha256,
+                        bucket: entry.bucket,
+                        key: entry.key,
+                        publicUrl: entry.publicUrl,
+                        reusedExisting: entry.reusedExisting,
+                        uploaded: entry.uploaded,
+                        fetchedAt: entry.fetchedAt,
+                      },
                     },
-                  },
-                  url,
+                    url,
+                    companyContextBody
+                  ),
+                  url
                 ),
-              },
-            );
-            addedJobs.push(addedJob);
-            cached.push(entry);
+              }
+            )
+            addedJobs.push(addedJob)
+            cached.push(entry)
           } catch (err: any) {
             const message = err?.message
               ? String(err.message)
-              : "Failed to cache or enqueue PDF";
-            request.log.warn({ err, url }, "parsePdf cachePdf failed for URL");
-            cacheErrors.push({ url, error: message });
+              : 'Failed to cache or enqueue PDF'
+            request.log.warn({ err, url }, 'parsePdf cachePdf failed for URL')
+            cacheErrors.push({ url, error: message })
           }
-          continue;
+          continue
         }
-        const perUrlThreadId = randomUUID();
+        const perUrlThreadId = randomUUID()
         const jobOptions = {
           forceReindex,
           threadId: perUrlThreadId,
@@ -505,47 +509,54 @@ export async function readQueuesRoute(app: FastifyInstance) {
           callbackUrl,
           ...(resolvedName === QUEUE_NAMES.PARSE_PDF
             ? {
-                data: withUrlReportYearForDisplay({ sourceUrl: url }, url),
+                data: withUrlReportYearForDisplay(
+                  mergeJobDataWithCompanyContext(
+                    { sourceUrl: url },
+                    url,
+                    companyContextBody
+                  ),
+                  url
+                ),
               }
             : {}),
-        };
+        }
         const addedJob = await queueService.addJob(
           resolvedName,
           url,
           autoApprove,
-          jobOptions,
-        );
-        addedJobs.push(addedJob);
+          jobOptions
+        )
+        addedJobs.push(addedJob)
       }
 
       if (resolvedName === QUEUE_NAMES.PARSE_PDF && cachePdf) {
         if (cacheErrors.length > 0 && addedJobs.length === 0) {
           return reply.status(400).send({
             error:
-              "Could not cache or enqueue any PDFs from the provided URLs.",
+              'Could not cache or enqueue any PDFs from the provided URLs.',
             errors: cacheErrors,
-          });
+          })
         }
         if (cached.length > 0 || cacheErrors.length > 0) {
           return reply.send({
             jobs: addedJobs,
             cached,
             ...(cacheErrors.length > 0 ? { errors: cacheErrors } : {}),
-          });
+          })
         }
       }
 
-      return reply.send(addedJobs);
-    },
-  );
+      return reply.send(addedJobs)
+    }
+  )
 
   app.get(
-    "/stats",
+    '/stats',
     {
       schema: {
-        summary: "Get queue job stats",
-        description: "",
-        tags: ["Queues"],
+        summary: 'Get queue job stats',
+        description: '',
+        tags: ['Queues'],
         querystring: readQueueStatsQueryStringSchema,
         response: {
           200: queueStatsResponseSchema,
@@ -554,24 +565,24 @@ export async function readQueuesRoute(app: FastifyInstance) {
     },
     async (
       request: FastifyRequest<{
-        Querystring: { queue?: string };
+        Querystring: { queue?: string }
       }>,
-      reply,
+      reply
     ) => {
-      const { queue } = request.query;
-      const queueService = await QueueService.getQueueService();
-      const stats = await queueService.getQueueStats(queue);
-      return reply.send(stats);
-    },
-  );
+      const { queue } = request.query
+      const queueService = await QueueService.getQueueService()
+      const stats = await queueService.getQueueStats(queue)
+      return reply.send(stats)
+    }
+  )
 
   app.get(
-    "/:name/:id",
+    '/:name/:id',
     {
       schema: {
-        summary: "Get job data",
-        description: "",
-        tags: ["Queues"],
+        summary: 'Get job data',
+        description: '',
+        tags: ['Queues'],
         params: readQueueJobPathParamsSchema,
         response: {
           200: queueJobResponseSchema,
@@ -581,31 +592,31 @@ export async function readQueuesRoute(app: FastifyInstance) {
     },
     async (
       request: FastifyRequest<{
-        Params: { name: string; id: string };
+        Params: { name: string; id: string }
       }>,
-      reply,
+      reply
     ) => {
-      const { name, id } = request.params;
-      const queueService = await QueueService.getQueueService();
+      const { name, id } = request.params
+      const queueService = await QueueService.getQueueService()
       try {
-        const jobData = await queueService.getJobData(name, id);
-        return reply.send(jobData);
+        const jobData = await queueService.getJobData(name, id)
+        return reply.send(jobData)
       } catch (error) {
         return reply
           .status(404)
-          .send({ error: "Job does not exist in this queue" });
+          .send({ error: 'Job does not exist in this queue' })
       }
-    },
-  );
+    }
+  )
 
   app.post(
-    "/:name/:id/rerun",
+    '/:name/:id/rerun',
     {
       schema: {
-        summary: "Re-run a job (resume delayed job or retry failed job)",
+        summary: 'Re-run a job (resume delayed job or retry failed job)',
         description:
-          "Resumes a delayed job (e.g., approval pending) or retries a failed job. Optionally allows updating job data before re-running. For completed jobs, creates a new job with the same data.",
-        tags: ["Queues"],
+          'Resumes a delayed job (e.g., approval pending) or retries a failed job. Optionally allows updating job data before re-running. For completed jobs, creates a new job with the same data.',
+        tags: ['Queues'],
         params: readQueueJobPathParamsSchema,
         body: rerunQueueJobBodySchema,
         response: {
@@ -617,44 +628,44 @@ export async function readQueuesRoute(app: FastifyInstance) {
     },
     async (
       request: FastifyRequest<{
-        Params: { name: string; id: string };
+        Params: { name: string; id: string }
         Body: {
-          data?: Record<string, any>;
-        };
+          data?: Record<string, any>
+        }
       }>,
-      reply,
+      reply
     ) => {
-      const { name, id } = request.params;
-      const { data: dataOverrides } = request.body;
+      const { name, id } = request.params
+      const { data: dataOverrides } = request.body
 
-      const queueService = await QueueService.getQueueService();
+      const queueService = await QueueService.getQueueService()
 
       try {
-        const updatedJob = await queueService.rerunJob(name, id, dataOverrides);
-        return reply.send(updatedJob);
+        const updatedJob = await queueService.rerunJob(name, id, dataOverrides)
+        return reply.send(updatedJob)
       } catch (error: any) {
-        if (error.message?.includes("not found")) {
+        if (error.message?.includes('not found')) {
           return reply
             .status(404)
-            .send({ error: "Job does not exist in this queue" });
+            .send({ error: 'Job does not exist in this queue' })
         }
-        if (error.message?.includes("already")) {
-          return reply.status(400).send({ error: error.message });
+        if (error.message?.includes('already')) {
+          return reply.status(400).send({ error: error.message })
         }
-        app.log.error(error, "Error re-running job");
-        return reply.status(500).send({ error: "Failed to re-run job" });
+        app.log.error(error, 'Error re-running job')
+        return reply.status(500).send({ error: 'Failed to re-run job' })
       }
-    },
-  );
+    }
+  )
 
   app.post(
-    "/:name/:id/rerun-and-save",
+    '/:name/:id/rerun-and-save',
     {
       schema: {
-        summary: "Re-run extract-emissions for this process and save results",
+        summary: 'Re-run extract-emissions for this process and save results',
         description:
-          "From a follow-up job (e.g. scope1, scope2, scope1+2, or scope3), find the original EXTRACT_EMISSIONS job and enqueue a new one with runOnly set to the requested scopes. This overwrites any existing runOnly value.",
-        tags: ["Queues"],
+          'From a follow-up job (e.g. scope1, scope2, scope1+2, or scope3), find the original EXTRACT_EMISSIONS job and enqueue a new one with runOnly set to the requested scopes. This overwrites any existing runOnly value.',
+        tags: ['Queues'],
         params: readQueueJobPathParamsSchema,
         body: rerunAndSaveQueueJobBodySchema,
         response: {
@@ -666,60 +677,60 @@ export async function readQueuesRoute(app: FastifyInstance) {
     },
     async (
       request: FastifyRequest<{
-        Params: { name: string; id: string };
-        Body: { scopes: string[] };
+        Params: { name: string; id: string }
+        Body: { scopes: string[] }
       }>,
-      reply,
+      reply
     ) => {
-      const { name, id } = request.params;
-      const { scopes } = request.body;
+      const { name, id } = request.params
+      const { scopes } = request.body
 
-      const queueService = await QueueService.getQueueService();
+      const queueService = await QueueService.getQueueService()
 
       try {
         const newJob = await queueService.rerunExtractEmissionsFromFollowup(
           name,
           id,
-          scopes,
-        );
-        return reply.send(newJob);
+          scopes
+        )
+        return reply.send(newJob)
       } catch (error: any) {
-        const msg = error?.message ?? "";
+        const msg = error?.message ?? ''
 
-        if (msg.includes("EXTRACT_EMISSIONS job") || msg.includes("threadId")) {
-          return reply.status(404).send({ error: msg });
+        if (msg.includes('EXTRACT_EMISSIONS job') || msg.includes('threadId')) {
+          return reply.status(404).send({ error: msg })
         }
 
-        if (msg.includes("Unknown queue")) {
-          return reply.status(400).send({ error: msg });
+        if (msg.includes('Unknown queue')) {
+          return reply.status(400).send({ error: msg })
         }
 
-        app.log.error(error, "Error in rerun-and-save");
+        app.log.error(error, 'Error in rerun-and-save')
         return reply
           .status(500)
-          .send({ error: "Failed to rerun and save emissions" });
+          .send({ error: 'Failed to rerun and save emissions' })
       }
-    },
-  );
+    }
+  )
 
   app.post(
-    "/rerun-by-worker",
+    '/rerun-by-worker',
     {
       schema: {
         summary:
-          "Re-run all jobs that match a given worker name (using rerun-and-save)",
+          'Re-run all jobs that match a given worker name (using rerun-and-save)',
         description:
-          "Re-runs all jobs across one or more queues whose data.runOnly[] contains the specified worker name using the rerun-and-save approach (finds original EXTRACT_EMISSIONS job and creates new one with specified scopes). Defaults to completed and failed jobs.",
-        tags: ["Queues"],
+          'Re-runs all jobs across one or more queues whose data.runOnly[] contains the specified worker name using the rerun-and-save approach (finds original EXTRACT_EMISSIONS job and creates new one with specified scopes). Defaults to completed and failed jobs.',
+        tags: ['Queues'],
         body: rerunJobsByWorkerBodySchema,
         response: {
           200: z.object({
             totalMatched: z
               .number()
-              .describe("Total number of jobs that matched the criteria"),
+              .describe('Total number of jobs that matched the criteria'),
             perQueue: z
               .record(z.number())
-              .describe("Number of matched jobs per queue name"),
+              .describe('Number of matched jobs per queue name'),
           }),
         },
       },
@@ -727,28 +738,28 @@ export async function readQueuesRoute(app: FastifyInstance) {
     async (
       request: FastifyRequest<{
         Body: {
-          workerName: string;
-          statuses?: JobType[];
-          queues?: string[];
-          limit?: number | "all";
-        };
+          workerName: string
+          statuses?: JobType[]
+          queues?: string[]
+          limit?: number | 'all'
+        }
       }>,
-      reply,
+      reply
     ) => {
-      const { workerName, statuses, queues, limit } = request.body;
+      const { workerName, statuses, queues, limit } = request.body
 
-      const queueService = await QueueService.getQueueService();
+      const queueService = await QueueService.getQueueService()
 
       const resolvedQueues =
-        queues && queues.length > 0 ? queues : Object.values(QUEUE_NAMES);
+        queues && queues.length > 0 ? queues : Object.values(QUEUE_NAMES)
 
       const result = await queueService.rerunJobsByWorkerName(workerName, {
         queueNames: resolvedQueues,
         statuses,
         limit,
-      });
+      })
 
-      return reply.send(result);
-    },
-  );
+      return reply.send(result)
+    }
+  )
 }

--- a/src/schemas/request.ts
+++ b/src/schemas/request.ts
@@ -1,65 +1,158 @@
-import { string, z } from "zod";
-import { jobStatusSchema } from "./common";
+import { string, z } from 'zod'
+import { jobStatusSchema } from './common'
 
 export const readQueuePathParamsSchema = z.object({
-    name: z.string()
-});
+  name: z.string(),
+})
 
 export const readProcessPathParamsSchema = z.object({
-    id: z.string()
-});
+  id: z.string(),
+})
 
 export const readProcessesQueryStringSchema = z.object({
-    batchId: z.string().optional().describe('Filter to processes in this batch only'),
-});
+  batchId: z
+    .string()
+    .optional()
+    .describe('Filter to processes in this batch only'),
+})
 
 export const readQueueQueryStringSchema = z.object({
-    status: jobStatusSchema.optional()
-});
+  status: jobStatusSchema.optional(),
+})
 
 export const readQueueStatsQueryStringSchema = z.object({
-    queue: string().optional()
-});
+  queue: string().optional(),
+})
 
 export const readQueueJobPathParamsSchema = z.object({
-    name: z.string(),
-    id: z.string()
-});
+  name: z.string(),
+  id: z.string(),
+})
 
 export const readProcessesByCompanyQueryStringSchema = z.object({
-    page: z.coerce.number().int().min(1).optional(),
-    pageSize: z.coerce.number().int().min(1).max(500).optional(),
-    batchId: z.string().optional().describe('Filter to processes (reports) in this batch only'),
-});
+  page: z.coerce.number().int().min(1).optional(),
+  pageSize: z.coerce.number().int().min(1).max(500).optional(),
+  batchId: z
+    .string()
+    .optional()
+    .describe('Filter to processes (reports) in this batch only'),
+})
 
 // Accept both camelCase and kebab-case for the reindex flag.
 // Normalization to camelCase is done in the route handler to avoid schema transforms
 // that can accidentally mark fields as required in JSON schema.
+const wikidataIdSchema = z
+  .string()
+  .regex(/^Q\d+$/, 'Expected Wikidata Q-id (e.g. Q380)')
+
+export const pipelineCompanyContextSchema = z.object({
+  companyId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Garbo Company.id when already known'),
+  companyName: z
+    .string()
+    .optional()
+    .describe('Trusted company name; skips LLM name extraction when set'),
+  wikidataId: wikidataIdSchema
+    .optional()
+    .describe('Wikidata Q-id when already known'),
+})
+
+export const addQueueJobUrlContextSchema = pipelineCompanyContextSchema.extend({
+  url: z.string().url(),
+})
+
 export const addQueueJobBodySchema = z.object({
-    autoApprove: z.boolean().optional().default(false),
-    urls: z.array(string().url()),
-    forceReindex: z.boolean().optional().describe('Re-index markdown even if already indexed'),
-    replaceAllEmissions: z.boolean().optional().default(false).describe('Replace all scope 1,2,3 emissions and totals (delete old ones from all periods) before adding new ones'),
-    runOnly: z.array(z.string()).optional().describe('Array of worker/queue names to run (limits pipeline execution to specified steps)'),
-    batchId: z.string().optional().describe('Optional batch ID to group related reports for filtering'),
-    tags: z.array(z.string()).optional().describe('Optional tags to set on the job/report at creation (e.g. for filtering); passed through to Garbo API. Worker may set or extend tags later'),
-    cachePdf: z.boolean().optional().default(false).describe('When true (parsePdf only), fetch each URL and cache the PDF to S3 before enqueueing, so pipeline reads from storage instead of the source URL'),
-    callbackUrl: z.string().url().optional().describe('URL to POST {url} to after indexMarkdown completes. Skips emissions extraction when set.'),
-});
+  autoApprove: z.boolean().optional().default(false),
+  urls: z.array(string().url()),
+  /** Optional company identity applied to every URL in this request. */
+  pipelineCompany: pipelineCompanyContextSchema.optional(),
+  /** Per-URL company identity; overrides pipelineCompany for matching urls. */
+  urlContexts: z.array(addQueueJobUrlContextSchema).optional(),
+  forceReindex: z
+    .boolean()
+    .optional()
+    .describe('Re-index markdown even if already indexed'),
+  replaceAllEmissions: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Replace all scope 1,2,3 emissions and totals (delete old ones from all periods) before adding new ones'
+    ),
+  runOnly: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Array of worker/queue names to run (limits pipeline execution to specified steps)'
+    ),
+  batchId: z
+    .string()
+    .optional()
+    .describe('Optional batch ID to group related reports for filtering'),
+  tags: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Optional tags to set on the job/report at creation (e.g. for filtering); passed through to Garbo API. Worker may set or extend tags later'
+    ),
+  cachePdf: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'When true (parsePdf only), fetch each URL and cache the PDF to S3 before enqueueing, so pipeline reads from storage instead of the source URL'
+    ),
+  callbackUrl: z
+    .string()
+    .url()
+    .optional()
+    .describe(
+      'URL to POST {url} to after indexMarkdown completes. Skips emissions extraction when set.'
+    ),
+})
 
 export const rerunQueueJobBodySchema = z.object({
-    data: z.record(z.any()).optional().describe('Optional job data overrides. Will merge with existing job data before re-running'),
-}); 
+  data: z
+    .record(z.any())
+    .optional()
+    .describe(
+      'Optional job data overrides. Will merge with existing job data before re-running'
+    ),
+})
 
 export const rerunJobsByWorkerBodySchema = z.object({
-    workerName: z.string().describe('Name of the worker / pipeline step to re-run (e.g. "scope1+2")'),
-    statuses: z.array(jobStatusSchema).optional().describe('Optional list of job statuses to consider (defaults to completed and failed jobs)'),
-    queues: z.array(z.string()).optional().describe('Optional list of queue names to restrict the rerun to (defaults to all known queues)'),
-    limit: z.union([z.number(), z.literal('all')]).optional().default(5).describe('Maximum number of companies to rerun (defaults to 5). Use "all" to rerun all companies.'),
-});
+  workerName: z
+    .string()
+    .describe('Name of the worker / pipeline step to re-run (e.g. "scope1+2")'),
+  statuses: z
+    .array(jobStatusSchema)
+    .optional()
+    .describe(
+      'Optional list of job statuses to consider (defaults to completed and failed jobs)'
+    ),
+  queues: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Optional list of queue names to restrict the rerun to (defaults to all known queues)'
+    ),
+  limit: z
+    .union([z.number(), z.literal('all')])
+    .optional()
+    .default(5)
+    .describe(
+      'Maximum number of companies to rerun (defaults to 5). Use "all" to rerun all companies.'
+    ),
+})
 
 export const rerunAndSaveQueueJobBodySchema = z.object({
-    scopes: z.array(z.string())
-        .min(1)
-        .describe('Scopes to rerun, e.g. [\"scope1\"], [\"scope2\"], [\"scope1+2\"], [\"scope3\"], or [\"scope1\", \"scope2\", \"scope3\"]'),
-});
+  scopes: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      'Scopes to rerun, e.g. [\"scope1\"], [\"scope2\"], [\"scope1+2\"], [\"scope3\"], or [\"scope1\", \"scope2\", \"scope3\"]'
+    ),
+})


### PR DESCRIPTION
## Summary
- Accept optional `pipelineCompany` and per-URL `urlContexts` on parsePdf enqueue
- Merge companyId, companyName, and wikidataId into job data for Garbo precheck resolution

## Test plan
- [ ] Enqueue with urlContexts containing wikidataId — job data includes wikidata node
- [ ] Deploy with garbo + validate-frontend duplicate-prevention PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes enqueue job payload shape for parsePdf, which affects company resolution downstream; scope is limited to optional fields and covered by tests, but wrong context could mis-attribute reports.
> 
> **Overview**
> Adds optional **`pipelineCompany`** (request-wide) and **`urlContexts`** (per URL) on queue enqueue, validated with UUID company IDs and Wikidata `Q\d+` ids.
> 
> When enqueueing **parsePdf** jobs (URL enqueue and `cachePdf` path), those fields are merged into job `data` as `companyId`, `companyName`, and `wikidata: { node }`, with per-URL context overriding the pipeline default. New helpers in `pipelineCompanyJobData.ts` implement resolution and trimming; unit tests cover merge, fallback, and precedence.
> 
> The multipart **`/parsePdf/upload`** path is unchanged and does not accept or merge company context yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a48f6e0230ffcc82d7cb105ba9494f46fa66e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->