### PR TITLE
[Prod] Minor Version Bump v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipeline-status",
-  "version": "0.4.5-rc.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pipeline-status",
-      "version": "0.4.5-rc.1",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1002.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-status",
-  "version": "0.4.5-rc.1",
+  "version": "0.5.0",
   "scripts": {
     "build": "tsc",
     "start": "node --max-old-space-size=4096 --import tsx src/index.ts",


### PR DESCRIPTION
## Release type

- [x] Minor

## Version / artifacts

- **Version being released:** v0.5.0
- **Image:** `ghcr.io/klimatbyran/pipeline-api:0.5.0`
- **Rollback target:** v0.4.4

## What's being released

Everything merged since **v0.4.4** (staging validated on `0.4.5-rc.x`):

### Pass company identity into parsePdf jobs ([#78](https://github.com/Klimatbyran/pipeline-api/pull/78))

- Accept `pipelineCompany` and per-URL `urlContexts` on job create
- Forward `companyId`, `companyName`, and `wikidataId` into Garbo precheck resolution
- Supports Validate dedup flow (identifiers-first before name-only create)

## Deployment notes

- Deploy together with **Garbo** company-dedup release ([#1380](https://github.com/Klimatbyran/garbo/pull/1380) + [#1381](https://github.com/Klimatbyran/garbo/pull/1381)) and **Validate v1.16.0**
- No DB migrations

## Smoke test (production)

- [ ] Upload/crawler/registry enqueue sends company context when known
- [ ] parsePdf jobs in Bull board show `companyId` / `wikidataId` when provided
- [ ] Existing flows without company context still work

## Checklist

- [x] Version updated (`0.5.0`)
- [ ] QA verified in staging (`0.4.5-rc.x`)
- [x] Rollback target recorded (v0.4.4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is a version-only change; functional risk is tied to the already-staged company-context behavior and coordinated Garbo/Validate rollout, not new code in this PR.
> 
> **Overview**
> **Production minor release** — bumps `pipeline-status` from `0.4.5-rc.1` to **0.5.0** in `package.json` and `package-lock.json` only.
> 
> This tag ships work already merged since v0.4.4 (validated on `0.4.5-rc.x`), chiefly **company identity on parsePdf jobs**: optional `pipelineCompany` and per-URL `urlContexts` on job create, forwarding `companyId`, `companyName`, and `wikidataId` into downstream Garbo precheck resolution for Validate’s identifiers-first dedup flow.
> 
> Deploy with Garbo company-dedup and **Validate v1.16.0**; no DB migrations. Rollback target: **v0.4.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49a9125193517566f71aa1fc0eb37335e79bc6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->