### PR TITLE
Company link partial match approval API

### DIFF
--- a/src/schemas/response.ts
+++ b/src/schemas/response.ts
@@ -1,9 +1,9 @@
-import { z } from 'zod';
-import { jobStatusSchema, processStatusSchema } from './common';
+import { z } from "zod";
+import { jobStatusSchema, processStatusSchema } from "./common";
 
 export const approvalDataSchema = z.object({
   oldValue: z.any(),
-  newValue: z.any()
+  newValue: z.any(),
 });
 
 export const approvalSchema = z.object({
@@ -13,57 +13,63 @@ export const approvalSchema = z.object({
   approved: z.boolean().default(false),
   metadata: z.object({
     comment: z.string().optional(),
-    source: z.string().optional()
-  })
-})
+    source: z.string().optional(),
+  }),
+});
 
 export const baseJobSchema = z.object({
-    name: z.string(),
-    id: z.string().optional(),
-    url: z.string().url().optional(),
-    autoApprove: z.boolean().optional().default(false),
-    timestamp: z.number(),
-    processedOn: z.number().optional(),
-    processId: z.string().optional(),
-    threadId: z.string().optional(),
-    queue: z.string(),
-    processedBy: z.string().optional(),
-    finishedOn: z.number().optional(),
-    attemptsMade: z.number(),
-    failedReason: z.string().optional(),
-    stacktrace: z.array(z.string()).optional(),
-    progress: z.number().optional(),
-    opts: z.record(z.string(), z.any()).optional(),
-    delay: z.number().optional(),
-    approval: approvalSchema.optional(),
-    status: jobStatusSchema.optional(),
+  name: z.string(),
+  id: z.string().optional(),
+  url: z.string().url().optional(),
+  autoApprove: z.boolean().optional().default(false),
+  timestamp: z.number(),
+  processedOn: z.number().optional(),
+  processId: z.string().optional(),
+  threadId: z.string().optional(),
+  queue: z.string(),
+  processedBy: z.string().optional(),
+  finishedOn: z.number().optional(),
+  attemptsMade: z.number(),
+  failedReason: z.string().optional(),
+  stacktrace: z.array(z.string()).optional(),
+  progress: z.number().optional(),
+  opts: z.record(z.string(), z.any()).optional(),
+  delay: z.number().optional(),
+  approval: approvalSchema.optional(),
+  status: jobStatusSchema.optional(),
+  companyId: z.string().optional(),
+  companyName: z.string().optional(),
 });
 
 export const dataJobSchema = baseJobSchema.extend({
-    data: z.any().optional(),    
-    returnvalue: z.any().optional(),
+  data: z.any().optional(),
+  returnvalue: z.any().optional(),
 });
 
 export const queueStatusSchema = z.object({
   name: z.string(),
-  status: z.record(jobStatusSchema, z.number().optional())
-})
+  status: z.record(jobStatusSchema, z.number().optional()),
+});
 
 export const processSchema = z.object({
   id: z.string(),
   company: z.string().optional(),
+  companyId: z.string().optional(),
   wikidataId: z.string().optional(),
   year: z.number().optional(),
   status: processStatusSchema.optional(),
   jobs: z.array(baseJobSchema),
   startedAt: z.number().optional(),
-  finishedAt: z.number().optional()
-})
+  finishedAt: z.number().optional(),
+});
 
 export const companyProcessSchema = z.object({
   company: z.string().optional(),
+  companyId: z.string().optional(),
   wikidataId: z.string().optional(),
-  processes: z.array(processSchema.omit({company: true, wikidataId: true}))
+  processes: z.array(
+    processSchema.omit({ company: true, wikidataId: true, companyId: true }),
+  ),
 });
 
 export const queueStatsResponseSchema = z.array(queueStatusSchema);
@@ -78,7 +84,8 @@ export const queueJobResponseSchema = dataJobSchema;
 
 export const processesResponseSchema = z.array(processSchema);
 
-export const processesGroupedByCompanyResponseSchema = z.array(companyProcessSchema);
+export const processesGroupedByCompanyResponseSchema =
+  z.array(companyProcessSchema);
 
 export const error404ResponseSchema = z.object({
   error: z.string(),

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -35,24 +35,12 @@ export class ProcessService {
       undefined,
       batchId,
     );
-    // Debug: log number of jobs fetched across all queues
-    // Using console here; Fastify logger isn't directly available in service layer
     console.info("[ProcessService] getProcesses: jobs fetched", {
       count: jobs.length,
     });
     const jobProcesses: Record<string, DataJob[]> = {};
     for (const job of jobs) {
-      // Group jobs by threadId if available, otherwise group by company name
-      // This prevents jobs from different companies without threadId from being grouped together
-      let key: string;
-      if (job.data.threadId) {
-        key = job.data.threadId;
-      } else {
-        // For jobs without threadId, create a unique key per company
-        // This ensures jobs from different companies are in separate processes
-        const companyName = job.data.companyName ?? "unknown";
-        key = `unknown-${companyName}`;
-      }
+      const key = this.processJobsGroupKey(job);
       if (!jobProcesses[key]) {
         jobProcesses[key] = [];
       }
@@ -71,24 +59,71 @@ export class ProcessService {
   public async getProcessesGroupedByCompany(
     batchId?: string,
   ): Promise<CompanyProcess[]> {
-    const processes = await this.getProcesses(batchId);
-    const companyProcesses: Record<string, CompanyProcess> = {};
-    for (const process of processes) {
-      // Use the process's company name, or "unknown" if not available
-      const company = process.company ?? "unknown";
-      if (companyProcesses[company]) {
-        companyProcesses[company].processes.push(process);
-      } else {
-        companyProcesses[company] = {
-          company: process.company,
-          processes: [process],
-        };
+    const jobs = await this.queueService.getDataJobs(
+      undefined,
+      undefined,
+      undefined,
+      batchId,
+    );
+
+    const processJobsByKey: Record<string, DataJob[]> = {};
+    for (const job of jobs) {
+      const key = this.processJobsGroupKey(job);
+      if (!processJobsByKey[key]) {
+        processJobsByKey[key] = [];
       }
-      if (process.wikidataId && company !== "unknown") {
-        companyProcesses[company].wikidataId = process.wikidataId;
+      processJobsByKey[key].push(job);
+    }
+
+    const companyProcesses: Record<string, CompanyProcess> = {};
+    const companyJobs: Record<string, DataJob[]> = {};
+
+    for (const processJobs of Object.values(processJobsByKey)) {
+      const process = this.createProcess(processJobs);
+      const key = process.companyId
+        ? `id:${process.companyId}`
+        : `name:${process.company ?? "unknown"}`;
+
+      if (!companyProcesses[key]) {
+        companyProcesses[key] = {
+          company: process.company,
+          companyId: process.companyId,
+          wikidataId: process.wikidataId,
+          processes: [],
+        };
+        companyJobs[key] = [];
+      }
+
+      companyProcesses[key].processes.push({
+        id: process.id,
+        year: process.year,
+        status: process.status,
+        jobs: process.jobs,
+        startedAt: process.startedAt,
+        finishedAt: process.finishedAt,
+      });
+
+      companyJobs[key].push(...processJobs);
+
+      if (process.wikidataId && process.company !== "unknown") {
+        companyProcesses[key].wikidataId = process.wikidataId;
       }
     }
-    const grouped = Object.values(companyProcesses);
+
+    const grouped = Object.entries(companyProcesses).map(([key, entry]) => {
+      const canonicalName = this.pickCanonicalCompanyName(
+        companyJobs[key] ?? [],
+      );
+      if (canonicalName) {
+        entry.company = canonicalName;
+      }
+      const companyId = this.pickCompanyId(companyJobs[key] ?? []);
+      if (companyId) {
+        entry.companyId = companyId;
+      }
+      return entry;
+    });
+
     console.info(
       "[ProcessService] getProcessesGroupedByCompany: companies grouped",
       { count: grouped.length },
@@ -122,43 +157,95 @@ export class ProcessService {
     return Array.from(batchIds).sort();
   }
 
+  /**
+   * One pipeline run (process) per upload thread. Company-level grouping uses
+   * companyId separately in getProcessesGroupedByCompany — do not key runs by
+   * companyId here or multiple PDFs on the same company collapse into one run.
+   */
+  private processJobsGroupKey(job: DataJob): string {
+    if (job.data?.threadId) {
+      return job.data.threadId;
+    }
+    const companyName = job.data?.companyName ?? "unknown";
+    return `unknown-${companyName}`;
+  }
+
+  private pickCompanyId(jobs: DataJob[]): string | undefined {
+    for (const job of jobs) {
+      const id = job.data?.companyId;
+      if (typeof id === "string" && id.trim()) return id.trim();
+    }
+    return undefined;
+  }
+
+  private pickCanonicalCompanyName(jobs: DataJob[]): string | undefined {
+    for (const job of jobs) {
+      const approval = job.approval;
+      if (approval?.approved && approval.type === "companyLink") {
+        const newValue = approval.data?.newValue as
+          Record<string, unknown> | undefined;
+        const displayName = newValue?.displayName;
+        if (typeof displayName === "string" && displayName.trim()) {
+          return displayName.trim();
+        }
+      }
+    }
+
+    const sorted = [...jobs].sort((a, b) => b.timestamp - a.timestamp);
+    for (const job of sorted) {
+      const name = job.data?.companyName;
+      if (typeof name === "string" && name.trim()) return name.trim();
+    }
+    return undefined;
+  }
+
   private createProcess(jobs: DataJob[]): Process {
     let id: string | undefined;
     let wikidataId: string | undefined;
     let company: string | undefined;
+    let companyId: string | undefined;
     let year: number | undefined;
 
     for (const job of jobs) {
-      if (job.data.threadId) {
+      if (job.data?.threadId) {
         id = job.data.threadId;
       }
-      if (job.data.wikidata) {
+      if (job.data?.wikidata) {
         wikidataId = job.data.wikidata.node;
       }
-      if (job.data.companyName) {
+      if (job.data?.companyId) {
+        companyId = job.data.companyId;
+      }
+      if (job.data?.companyName) {
         company = job.data.companyName;
       }
-      const jobYear = job.data.reportYear ?? job.data.documentReportYear;
+      const jobYear = job.data?.reportYear ?? job.data?.documentReportYear;
       if (jobYear !== undefined && jobYear !== null) {
         year = Number(jobYear);
       }
     }
 
+    company = this.pickCanonicalCompanyName(jobs) ?? company;
+    companyId = this.pickCompanyId(jobs) ?? companyId;
+
     const startedAt = Math.min(...jobs.map((job) => job.timestamp));
-    const finishedAt = jobs.reduce((completionTime, job) => {
-      if (job.finishedOn === undefined || completionTime === undefined) {
-        return undefined;
-      } else {
-        return Math.max(completionTime, job.finishedOn);
-      }
-    }, 0);
+    const finishedOnValues = jobs
+      .map((job) => job.finishedOn)
+      .filter((value): value is number => value !== undefined);
+    const finishedAt =
+      finishedOnValues.length > 0 ? Math.max(...finishedOnValues) : undefined;
 
     const baseJobs: BaseJob[] = jobs.map((job) => {
       const { data, returnvalue, ...rest } = job;
-      return rest;
+      return {
+        ...rest,
+        companyId:
+          typeof data?.companyId === "string" ? data.companyId : undefined,
+        companyName:
+          typeof data?.companyName === "string" ? data.companyName : undefined,
+      };
     });
 
-    // If no threadId, create a process id based on company name to keep them separate
     const processId = id ?? (company ? `unknown-${company}` : "unknown");
 
     const process: Process = {
@@ -166,6 +253,7 @@ export class ProcessService {
       jobs: baseJobs,
       wikidataId,
       company,
+      companyId,
       year,
       startedAt,
       finishedAt,

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -80,9 +80,10 @@ export class ProcessService {
 
     for (const processJobs of Object.values(processJobsByKey)) {
       const process = this.createProcess(processJobs);
-      const key = process.companyId
-        ? `id:${process.companyId}`
-        : `name:${process.company ?? "unknown"}`;
+      const groupCompanyId = this.pickCompanyId(processJobs);
+      const key = groupCompanyId
+        ? `id:${groupCompanyId}`
+        : `name:${this.pickRawCompanyName(processJobs) ?? "unknown"}`;
 
       if (!companyProcesses[key]) {
         companyProcesses[key] = {
@@ -111,24 +112,43 @@ export class ProcessService {
     }
 
     const grouped = Object.entries(companyProcesses).map(([key, entry]) => {
-      const canonicalName = this.pickCanonicalCompanyName(
-        companyJobs[key] ?? [],
-      );
+      const jobsForGroup = companyJobs[key] ?? [];
+      const canonicalName = this.pickCanonicalCompanyName(jobsForGroup);
       if (canonicalName) {
         entry.company = canonicalName;
       }
-      const companyId = this.pickCompanyId(companyJobs[key] ?? []);
+      const companyId = this.pickCompanyId(jobsForGroup);
       if (companyId) {
         entry.companyId = companyId;
       }
       return entry;
     });
 
+    const mergedByCompanyId = new Map<string, CompanyProcess>();
+    const unmerged: CompanyProcess[] = [];
+    for (const entry of grouped) {
+      if (entry.companyId) {
+        const existing = mergedByCompanyId.get(entry.companyId);
+        if (existing) {
+          existing.processes.push(...entry.processes);
+          if (!existing.wikidataId && entry.wikidataId) {
+            existing.wikidataId = entry.wikidataId;
+          }
+        } else {
+          mergedByCompanyId.set(entry.companyId, entry);
+        }
+      } else {
+        unmerged.push(entry);
+      }
+    }
+
+    const result = [...mergedByCompanyId.values(), ...unmerged];
+
     console.info(
       "[ProcessService] getProcessesGroupedByCompany: companies grouped",
-      { count: grouped.length },
+      { count: result.length },
     );
-    return grouped;
+    return result;
   }
 
   public async getPagedCompanyProcesses(
@@ -174,6 +194,15 @@ export class ProcessService {
     for (const job of jobs) {
       const id = job.data?.companyId;
       if (typeof id === "string" && id.trim()) return id.trim();
+    }
+    return undefined;
+  }
+
+  private pickRawCompanyName(jobs: DataJob[]): string | undefined {
+    const sorted = [...jobs].sort((a, b) => b.timestamp - a.timestamp);
+    for (const job of sorted) {
+      const name = job.data?.companyName;
+      if (typeof name === "string" && name.trim()) return name.trim();
     }
     return undefined;
   }
@@ -229,11 +258,12 @@ export class ProcessService {
     companyId = this.pickCompanyId(jobs) ?? companyId;
 
     const startedAt = Math.min(...jobs.map((job) => job.timestamp));
-    const finishedOnValues = jobs
-      .map((job) => job.finishedOn)
-      .filter((value): value is number => value !== undefined);
-    const finishedAt =
-      finishedOnValues.length > 0 ? Math.max(...finishedOnValues) : undefined;
+    const finishedAt = jobs.reduce<number | undefined>((completionTime, job) => {
+      if (job.finishedOn === undefined || completionTime === undefined) {
+        return undefined;
+      }
+      return Math.max(completionTime, job.finishedOn);
+    }, 0);
 
     const baseJobs: BaseJob[] = jobs.map((job) => {
       const { data, returnvalue, ...rest } = job;


### PR DESCRIPTION
## Summary
- Expose `partialNameMatch` and `displayName` on company-link approval job payloads.
- Apply staff display name updates when approving company links through the process API.

## Related PRs
- https://github.com/Klimatbyran/garbo/pull/1384
- https://github.com/Klimatbyran/validate-frontend/pull/283

## Test plan
- [ ] Approve a partial-match company link via pipeline API and verify display name is persisted
- [ ] Confirm job status responses include partial match metadata for validate UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how processes are grouped and labeled for list/group-by-company endpoints, which can alter UI grouping and displayed names without touching auth or persistence directly.
> 
> **Overview**
> Extends response schemas so **jobs**, **processes**, and **company-grouped** payloads can carry optional `companyId`, plus `companyName` on base jobs.
> 
> **ProcessService** now groups pipeline runs with a shared `processJobsGroupKey` (still **threadId**-first so multiple PDFs on one company do not collapse), then groups companies by **`companyId`** when present (otherwise by name), merges duplicate company buckets, and picks a **canonical company name** from approved **`companyLink`** approvals (`newValue.displayName`) before falling back to job `companyName`. Process creation propagates `companyId` onto processes and strips `companyId`/`companyName` onto each job in API responses without exposing full job `data`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c4cdcb2e0402ba2755bdf0ca070a273b472a6ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->