### PR TITLE
Treat failed extractLEI as non-blocking for run status

### DIFF
--- a/src/lib/bullmq.ts
+++ b/src/lib/bullmq.ts
@@ -62,6 +62,11 @@ export const QUEUE_NAMES = {
   WIKIPEDIA_UPLOAD: "wikipediaUpload",
 };
 
+/** Failed jobs on these queues must not mark the overall run as failed. */
+export const NON_BLOCKING_FAILURE_QUEUES = new Set<string>([
+  QUEUE_NAMES.EXTRACT_LEI,
+]);
+
 export const DEFAULT_PIPELINE_JOB_OPTIONS = {
   // Eviction is run-level (RunRetentionService / prune-runs), not per-queue.
   removeOnComplete: false,

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -1,4 +1,4 @@
-import { QUEUE_NAMES } from "../lib/bullmq";
+import { NON_BLOCKING_FAILURE_QUEUES, QUEUE_NAMES } from "../lib/bullmq";
 import {
   BaseJob,
   CompanyProcess,
@@ -293,7 +293,13 @@ export class ProcessService {
   }
 
   private getProcessStatus(jobs: DataJob[]): ProcessStatus {
-    if (jobs.find((job) => job.status === "failed")) {
+    const hasBlockingFailure = jobs.some(
+      (job) =>
+        job.status === "failed" &&
+        job.queue &&
+        !NON_BLOCKING_FAILURE_QUEUES.has(job.queue),
+    );
+    if (hasBlockingFailure) {
       return "failed";
     }
     if (


### PR DESCRIPTION
## Summary
- Add `NON_BLOCKING_FAILURE_QUEUES` with `extractLEI`.
- Overall run status stays `completed` when extractLEI fails but `sendCompanyLink` completes.

## Related PRs
- garbo: LEI validation in pipeline workers
- validate-frontend: non-blocking extractLEI in Jobbstatus step aggregation

## Test plan
- [ ] Confirm a run with failed extractLEI but completed sendCompanyLink shows as completed in process status
- [ ] Confirm a run with a failed checkDB job still shows as failed